### PR TITLE
CVE-2024-43484

### DIFF
--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>1.4.2</Version>
+    <Version>1.4.4</Version>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Helps exporting objects to an Excel file (.xlsx).</Description>
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -118,14 +118,14 @@ namespace SimpleExcelExporter
       rowDfn.Cells.Add(cellDfn);
     }
 
-    private static void GenerateWorksheetPartContent(WorksheetPart worksheetPart, SheetData sheetData, bool tabSeletedFlag)
+    private static void GenerateWorksheetPartContent(WorksheetPart worksheetPart, SheetData sheetData, bool tabSelectedFlag)
     {
       var worksheet = new Worksheet();
       var sheetDimension = new SheetDimension { Reference = "A1" };
 
       var sheetViews = new SheetViews();
 
-      var sheetView = new SheetView { TabSelected = tabSeletedFlag, WorkbookViewId = 0U };
+      var sheetView = new SheetView { TabSelected = tabSelectedFlag, WorkbookViewId = 0U };
       var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
 
       _ = sheetView.AppendChild(selection);

--- a/test/SimpleExcelExporterTests/SimpleExcelExporter.Tests.csproj
+++ b/test/SimpleExcelExporterTests/SimpleExcelExporter.Tests.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.1.0" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="4.2.2" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When a client consumes SimpleExcelExporter it gets the following warning :
```
warning NU1903: Package 'System.IO.Packaging' 8.0.0 has a known high severity vulnerability,
https://github.com/advisories/GHSA-f32c-w444-8ppv
```

This PR update `System.IO.Packaging` to version >= 8.01 by updating the `DocumentFormat.OpenXml` to the latest version 3.2.0