### PR TITLE
fix: make generated XLSX compatible with Apple Numbers (ECMA-376 strict)

### DIFF
--- a/SimpleExcelExporter.sln.DotSettings
+++ b/SimpleExcelExporter.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Calibri/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=officedocument/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preparator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preparators/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SimpleExcelExporter/ColumnReferenceHelper.cs
+++ b/src/SimpleExcelExporter/ColumnReferenceHelper.cs
@@ -1,0 +1,36 @@
+namespace SimpleExcelExporter
+{
+  using System;
+  using System.Text;
+
+  /// <summary>
+  /// Converts 1-indexed column numbers to their A1 spreadsheet notation.
+  /// </summary>
+  public static class ColumnReferenceHelper
+  {
+    /// <summary>
+    /// Converts a 1-indexed column number to its A1 letter notation.
+    /// </summary>
+    /// <param name="columnIndex">The 1-indexed column number (1 → "A", 27 → "AA").</param>
+    /// <returns>The column letters.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="columnIndex"/> is less than 1.</exception>
+    public static string ToLetters(int columnIndex)
+    {
+      if (columnIndex < 1)
+      {
+        throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, "Column index must be 1 or greater.");
+      }
+
+      var builder = new StringBuilder();
+      var remaining = columnIndex;
+      while (remaining > 0)
+      {
+        var modulo = (remaining - 1) % 26;
+        builder.Insert(0, (char)('A' + modulo));
+        remaining = (remaining - 1) / 26;
+      }
+
+      return builder.ToString();
+    }
+  }
+}

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>1.4.4</Version>
+    <Version>1.4.5-alpha</Version>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Helps exporting objects to an Excel file (.xlsx).</Description>

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -188,23 +188,6 @@ namespace SimpleExcelExporter
       return value.ToString();
     }
 
-    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
-    {
-      writer.WriteStartElement("Override", ContentTypesNamespace);
-      writer.WriteAttributeString("PartName", partName);
-      writer.WriteAttributeString("ContentType", contentType);
-      writer.WriteEndElement();
-    }
-
-    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
-    {
-      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
-      writer.WriteAttributeString("Id", id);
-      writer.WriteAttributeString("Type", type);
-      writer.WriteAttributeString("Target", target);
-      writer.WriteEndElement();
-    }
-
     private static void WriteCoreProperties(ZipArchive archive)
     {
       var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
@@ -224,6 +207,14 @@ namespace SimpleExcelExporter
         $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
         "</cp:coreProperties>");
       writer.Flush();
+    }
+
+    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
+    {
+      writer.WriteStartElement("Override", ContentTypesNamespace);
+      writer.WriteAttributeString("PartName", partName);
+      writer.WriteAttributeString("ContentType", contentType);
+      writer.WriteEndElement();
     }
 
     private static void WritePackageRelationships(ZipArchive archive)
@@ -254,6 +245,15 @@ namespace SimpleExcelExporter
 
       writer.WriteEndElement();
       writer.WriteEndDocument();
+    }
+
+    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
+    {
+      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
+      writer.WriteAttributeString("Id", id);
+      writer.WriteAttributeString("Type", type);
+      writer.WriteAttributeString("Target", target);
+      writer.WriteEndElement();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -92,6 +92,9 @@ namespace SimpleExcelExporter
       FixRelationshipTargets(buffer);
 
       buffer.Position = 0;
+      FixWorkbookNamespaceDeclaration(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
 
@@ -285,6 +288,50 @@ namespace SimpleExcelExporter
         using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         writer.Write(content);
       }
+    }
+
+    private static void FixWorkbookNamespaceDeclaration(MemoryStream buffer)
+    {
+      const string RelsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+      const string MainNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+      var relsDeclaration = $" xmlns:r=\"{RelsNamespace}\"";
+
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+      var entry = archive.GetEntry("xl/workbook.xml");
+      if (entry == null)
+      {
+        return;
+      }
+
+      string content;
+      using (var entryStream = entry.Open())
+      using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+      {
+        content = reader.ReadToEnd();
+      }
+
+      // If xmlns:r is already on <workbook>, nothing to do
+      var workbookTagEnd = content.IndexOf('>', content.IndexOf("<workbook", StringComparison.Ordinal));
+      var workbookTag = content.Substring(0, workbookTagEnd + 1);
+      if (workbookTag.Contains("xmlns:r=", StringComparison.Ordinal))
+      {
+        return;
+      }
+
+      // Remove xmlns:r declarations anywhere in the document
+      content = content.Replace(relsDeclaration, string.Empty, StringComparison.Ordinal);
+
+      // Add xmlns:r to the <workbook> element
+      content = content.Replace(
+        $"<workbook xmlns=\"{MainNamespace}\"",
+        $"<workbook xmlns:r=\"{RelsNamespace}\" xmlns=\"{MainNamespace}\"",
+        StringComparison.Ordinal);
+
+      entry.Delete();
+      var newEntry = archive.CreateEntry(entry.FullName);
+      using var writerStream = newEntry.Open();
+      using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+      writer.Write(content);
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -610,7 +610,6 @@ namespace SimpleExcelExporter
 
       if (cellDfn.Value == null)
       {
-        cell.InlineString = new InlineString { Text = new Text(string.Empty) };
         cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is DateTime dateTimeValue)
@@ -651,9 +650,12 @@ namespace SimpleExcelExporter
       }
       else if (cellDfn.Value is string stringValue)
       {
-        stringValue = XmlStringHelper.Sanitize(stringValue);
-        cell.InlineString = new InlineString { Text = new Text(stringValue) };
         cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
+        if (!string.IsNullOrEmpty(stringValue))
+        {
+          stringValue = XmlStringHelper.Sanitize(stringValue);
+          cell.InlineString = new InlineString { Text = new Text(stringValue) };
+        }
       }
       else if (cellDfn.Value is TimeSpan timeSpanValue)
       {

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -19,6 +19,14 @@ namespace SimpleExcelExporter
 
   public partial class SpreadsheetWriter
   {
+    private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    private const string PackageRelationshipsNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+    private const string RelationshipsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    private const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
     private readonly Dictionary<string, Attribute?> _cachedAttributes = [];
 
     private readonly Dictionary<string, (CellDfn, bool)> _headers = [];

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -7,6 +7,7 @@ namespace SimpleExcelExporter
   using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
+  using System.Text;
   using System.Text.RegularExpressions;
   using System.Xml;
   using System.Xml.Linq;
@@ -413,6 +414,23 @@ namespace SimpleExcelExporter
       }
 
       return index;
+    }
+
+    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
+    {
+      writer.WriteStartElement("Override", ContentTypesNamespace);
+      writer.WriteAttributeString("PartName", partName);
+      writer.WriteAttributeString("ContentType", contentType);
+      writer.WriteEndElement();
+    }
+
+    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
+    {
+      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
+      writer.WriteAttributeString("Id", id);
+      writer.WriteAttributeString("Type", type);
+      writer.WriteAttributeString("Target", target);
+      writer.WriteEndElement();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(
@@ -1057,6 +1075,129 @@ namespace SimpleExcelExporter
       {
         throw new DefinitionException("WorkBook could not be null or empty.");
       }
+    }
+
+    private void WriteContentTypes(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Types", ContentTypesNamespace);
+
+      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteAttributeString("Extension", "xml");
+      writer.WriteAttributeString("ContentType", "application/xml");
+      writer.WriteEndElement();
+
+      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteAttributeString("Extension", "rels");
+      writer.WriteAttributeString("ContentType", "application/vnd.openxmlformats-package.relationships+xml");
+      writer.WriteEndElement();
+
+      WriteOverride(writer, "/xl/workbook.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
+      WriteOverride(writer, "/xl/styles.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
+      WriteOverride(writer, "/docProps/core.xml", "application/vnd.openxmlformats-package.core-properties+xml");
+
+      for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
+      {
+        WriteOverride(writer, $"/xl/worksheets/sheet{i}.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+      }
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
+    }
+
+    private void WriteCoreProperties(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
+
+      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+      writer.WriteRaw(
+        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<cp:coreProperties " +
+        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+        "<dc:creator>SimpleExcelExporter</dc:creator>" +
+        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+        "</cp:coreProperties>");
+      writer.Flush();
+    }
+
+    private void WritePackageRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+        "xl/workbook.xml");
+
+      WriteRelationship(
+        writer,
+        "rId2",
+        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
+        "docProps/core.xml");
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
+    }
+
+    private void WriteWorkbookRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+        "styles.xml");
+
+      var rId = 2;
+      for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
+      {
+        WriteRelationship(
+          writer,
+          $"rId{rId}",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+          $"worksheets/sheet{i}.xml");
+        rId++;
+      }
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
     }
   }
 }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -62,49 +62,24 @@ namespace SimpleExcelExporter
 
     public void Write()
     {
-      using var buffer = new MemoryStream();
-
       // Adding core file properties is mandatory to avoid a problem with Google Spreadsheet transforming from XLSX to XLSM.
       // cf. https://stackoverflow.com/questions/70319867/avoid-google-spreadsheet-to-convert-an-xlsx-file-created-by-open-xml-sdk-to-xlsm
       // cf. https://github.com/OfficeDev/Open-XML-SDK/issues/1093
       // cf. https://issuetracker.google.com/issues/210875597
-      using (var document = SpreadsheetDocument.Create(buffer, SpreadsheetDocumentType.Workbook))
-      {
-        var coreFilePropPart = document.AddCoreFilePropertiesPart();
-        using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
-        {
-          var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-          writer.WriteRaw(
-            $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-            "<cp:coreProperties " +
-            "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
-            "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
-            "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
-            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-            "<dc:creator>SimpleExcelExporter</dc:creator>" +
-            $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
-            $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
-            "</cp:coreProperties>");
-          writer.Flush();
-        }
+      using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-        CreatePartsForExcel(document);
-      }
+      // Order matters : BuildStylesheetSkeleton must run BEFORE WriteWorksheets
+      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex) ;
+      // and both must run BEFORE WriteStyles serializes _stylesheet.
+      BuildStylesheetSkeleton();
 
-      buffer.Position = 0;
-      FixContentTypesXml(buffer);
-
-      buffer.Position = 0;
-      FixNamespacePrefixes(buffer);
-
-      buffer.Position = 0;
-      FixRelationshipTargets(buffer);
-
-      buffer.Position = 0;
-      FixWorkbookNamespaceDeclaration(buffer);
-
-      buffer.Position = 0;
-      buffer.CopyTo(_stream);
+      WriteContentTypes(archive);
+      WritePackageRels(archive);
+      WriteCoreProperties(archive);
+      WriteWorkbookRels(archive);
+      WriteWorkbook(archive);
+      WriteWorksheets(archive);
+      WriteStyles(archive);
     }
 
     [GeneratedRegex("Target=\"/([^\"]+)\"")]
@@ -416,6 +391,46 @@ namespace SimpleExcelExporter
       return index;
     }
 
+    private static string ToCellTypeAttribute(CellValues value)
+    {
+      if (value == CellValues.Boolean)
+      {
+        return "b";
+      }
+
+      if (value == CellValues.Date)
+      {
+        return "d";
+      }
+
+      if (value == CellValues.Error)
+      {
+        return "e";
+      }
+
+      if (value == CellValues.InlineString)
+      {
+        return "inlineStr";
+      }
+
+      if (value == CellValues.Number)
+      {
+        return "n";
+      }
+
+      if (value == CellValues.SharedString)
+      {
+        return "s";
+      }
+
+      if (value == CellValues.String)
+      {
+        return "str";
+      }
+
+      return value.ToString();
+    }
+
     private static void WriteOverride(XmlWriter writer, string partName, string contentType)
     {
       writer.WriteStartElement("Override", ContentTypesNamespace);
@@ -431,6 +446,57 @@ namespace SimpleExcelExporter
       writer.WriteAttributeString("Type", type);
       writer.WriteAttributeString("Target", target);
       writer.WriteEndElement();
+    }
+
+    private static void WriteCoreProperties(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
+
+      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+      writer.WriteRaw(
+        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<cp:coreProperties " +
+        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+        "<dc:creator>SimpleExcelExporter</dc:creator>" +
+        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+        "</cp:coreProperties>");
+      writer.Flush();
+    }
+
+    private static void WritePackageRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+        "xl/workbook.xml");
+
+      WriteRelationship(
+        writer,
+        "rId2",
+        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
+        "docProps/core.xml");
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(
@@ -1179,30 +1245,9 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
-    private void WriteCoreProperties(ZipArchive archive)
+    private void WriteStyles(ZipArchive archive)
     {
-      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
-      using var stream = entry.Open();
-      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
-
-      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-      writer.WriteRaw(
-        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-        "<cp:coreProperties " +
-        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
-        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
-        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
-        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-        "<dc:creator>SimpleExcelExporter</dc:creator>" +
-        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
-        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
-        "</cp:coreProperties>");
-      writer.Flush();
-    }
-
-    private void WritePackageRels(ZipArchive archive)
-    {
-      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
       using var stream = entry.Open();
       var settings = new XmlWriterSettings
       {
@@ -1212,74 +1257,191 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+      writer.WriteStartElement(string.Empty, "styleSheet", SpreadsheetMlNamespace);
 
-      WriteRelationship(
-        writer,
-        "rId1",
-        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
-        "xl/workbook.xml");
-
-      WriteRelationship(
-        writer,
-        "rId2",
-        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
-        "docProps/core.xml");
-
+      // numFmts
+      writer.WriteStartElement("numFmts", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "0");
       writer.WriteEndElement();
+
+      // fonts
+      writer.WriteStartElement("fonts", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("font", SpreadsheetMlNamespace);
+      writer.WriteStartElement("sz", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "11");
+      writer.WriteEndElement();
+      writer.WriteStartElement("name", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "Calibri");
+      writer.WriteEndElement();
+      writer.WriteStartElement("family", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "2");
+      writer.WriteEndElement();
+      writer.WriteStartElement("scheme", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "minor");
+      writer.WriteEndElement();
+      writer.WriteEndElement(); // font
+      writer.WriteEndElement(); // fonts
+
+      // fills
+      writer.WriteStartElement("fills", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("fill", SpreadsheetMlNamespace);
+      writer.WriteStartElement("patternFill", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("patternType", "none");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // borders
+      writer.WriteStartElement("borders", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("border", SpreadsheetMlNamespace);
+      foreach (var tag in new[] { "left", "right", "top", "bottom", "diagonal" })
+      {
+        writer.WriteStartElement(tag, SpreadsheetMlNamespace);
+        writer.WriteEndElement();
+      }
+
+      writer.WriteEndElement(); // border
+      writer.WriteEndElement(); // borders
+
+      // cellStyleXfs
+      writer.WriteStartElement("cellStyleXfs", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("numFmtId", "0");
+      writer.WriteAttributeString("fontId", "0");
+      writer.WriteAttributeString("fillId", "0");
+      writer.WriteAttributeString("borderId", "0");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // cellXfs — produced by CreateOrGetStylIndex, iterate CellFormats children
+      var cellFormats = _stylesheet.Elements<CellFormats>().FirstOrDefault();
+      var xfCount = cellFormats?.Count?.Value ?? 0;
+      writer.WriteStartElement("cellXfs", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", xfCount.ToString(CultureInfo.InvariantCulture));
+      if (cellFormats != null)
+      {
+        foreach (var xf in cellFormats.Elements<CellFormat>())
+        {
+          writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+          if (xf.NumberFormatId != null)
+          {
+            writer.WriteAttributeString("numFmtId", xf.NumberFormatId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FontId != null)
+          {
+            writer.WriteAttributeString("fontId", xf.FontId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FillId != null)
+          {
+            writer.WriteAttributeString("fillId", xf.FillId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.BorderId != null)
+          {
+            writer.WriteAttributeString("borderId", xf.BorderId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FormatId != null)
+          {
+            writer.WriteAttributeString("xfId", xf.FormatId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.ApplyNumberFormat?.Value == true)
+          {
+            writer.WriteAttributeString("applyNumberFormat", "1");
+          }
+
+          if (xf.ApplyFont?.Value == true)
+          {
+            writer.WriteAttributeString("applyFont", "1");
+          }
+
+          if (xf.ApplyFill?.Value == true)
+          {
+            writer.WriteAttributeString("applyFill", "1");
+          }
+
+          if (xf.ApplyBorder?.Value == true)
+          {
+            writer.WriteAttributeString("applyBorder", "1");
+          }
+
+          if (xf.ApplyAlignment?.Value == true)
+          {
+            writer.WriteAttributeString("applyAlignment", "1");
+          }
+
+          writer.WriteEndElement();
+        }
+      }
+
+      writer.WriteEndElement(); // cellXfs
+
+      // cellStyles
+      writer.WriteStartElement("cellStyles", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("cellStyle", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("name", "Normal");
+      writer.WriteAttributeString("xfId", "0");
+      writer.WriteAttributeString("builtinId", "0");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // tableStyles
+      writer.WriteStartElement("tableStyles", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "0");
+      writer.WriteAttributeString("defaultTableStyle", "TableStyleMedium9");
+      writer.WriteAttributeString("defaultPivotStyle", "PivotStyleLight16");
+      writer.WriteEndElement();
+
+      writer.WriteEndElement(); // styleSheet
       writer.WriteEndDocument();
-    }
-
-    private void WriteStyles(ZipArchive archive)
-    {
-      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
-      using var stream = entry.Open();
-      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
-
-      writer.WriteStartDocument(standalone: true);
-      writer.WriteElement(_stylesheet);
     }
 
     private void WriteWorkbook(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
       using var stream = entry.Open();
-      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
 
-      var workbook = new Workbook();
-      workbook.Append(new BookViews(new WorkbookView()));
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement(string.Empty, "workbook", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("xmlns", "r", null, RelationshipsNamespace);
 
-      var sheets = new Sheets();
-      _ = workbook.AppendChild(sheets);
+      writer.WriteStartElement("bookViews", SpreadsheetMlNamespace);
+      writer.WriteStartElement("workbookView", SpreadsheetMlNamespace);
+      writer.WriteEndElement();
+      writer.WriteEndElement();
 
+      writer.WriteStartElement("sheets", SpreadsheetMlNamespace);
       var sheetId = 1U;
       var rId = 2;
-      foreach (var worksheet in _workbookDfn.Worksheets)
+      foreach (var ws in _workbookDfn.Worksheets)
       {
-        _ = sheets.AppendChild(new Sheet
-        {
-          Name = worksheet.Name,
-          SheetId = sheetId,
-          Id = $"rId{rId}",
-        });
+        writer.WriteStartElement("sheet", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("name", ws.Name);
+        writer.WriteAttributeString("sheetId", sheetId.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("r", "id", RelationshipsNamespace, $"rId{rId}");
+        writer.WriteEndElement();
         sheetId++;
         rId++;
       }
 
-      writer.WriteStartDocument(standalone: true);
+      writer.WriteEndElement(); // sheets
 
-      var namespaceDeclarations = new List<KeyValuePair<string, string>>
-      {
-        new("r", RelationshipsNamespace),
-      };
-
-      writer.WriteStartElement(workbook, Array.Empty<OpenXmlAttribute>(), namespaceDeclarations);
-      foreach (var child in workbook.ChildElements)
-      {
-        writer.WriteElement(child);
-      }
-
-      writer.WriteEndElement();
+      writer.WriteEndElement(); // workbook
+      writer.WriteEndDocument();
     }
 
     private void WriteWorkbookRels(ZipArchive archive)
@@ -1324,33 +1486,105 @@ namespace SimpleExcelExporter
       {
         var entry = archive.CreateEntry($"xl/worksheets/sheet{count}.xml", CompressionLevel.Optimal);
         using var stream = entry.Open();
-        using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+        var settings = new XmlWriterSettings
+        {
+          Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+          CloseOutput = false,
+        };
+        using var writer = XmlWriter.Create(stream, settings);
 
         var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
 
         var reference = lastRowIndex == 0U || maxColumnCount == 0
           ? "A1"
           : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
-        var sheetDimension = new SheetDimension { Reference = reference };
-
-        var sheetViews = new SheetViews();
-        var sheetView = new SheetView { TabSelected = count == 1U, WorkbookViewId = 0U };
-        var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
-        _ = sheetView.AppendChild(selection);
-        _ = sheetViews.AppendChild(sheetView);
-
-        var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
-        var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
-
-        var worksheetElement = new Worksheet();
-        _ = worksheetElement.AppendChild(sheetDimension);
-        _ = worksheetElement.AppendChild(sheetViews);
-        _ = worksheetElement.AppendChild(sheetFormatProperties);
-        _ = worksheetElement.AppendChild(sheetData);
-        _ = worksheetElement.AppendChild(pageMargins);
 
         writer.WriteStartDocument(standalone: true);
-        writer.WriteElement(worksheetElement);
+        writer.WriteStartElement(string.Empty, "worksheet", SpreadsheetMlNamespace);
+
+        writer.WriteStartElement("dimension", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("ref", reference);
+        writer.WriteEndElement();
+
+        writer.WriteStartElement("sheetViews", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheetView", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("tabSelected", count == 1U ? "1" : "0");
+        writer.WriteAttributeString("workbookViewId", "0");
+        writer.WriteStartElement("selection", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("activeCell", "A1");
+        writer.WriteAttributeString("sqref", "A1");
+        writer.WriteEndElement();
+        writer.WriteEndElement(); // sheetView
+        writer.WriteEndElement(); // sheetViews
+
+        writer.WriteStartElement("sheetFormatPr", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("defaultRowHeight", "15");
+        writer.WriteAttributeString("defaultColWidth", "15");
+        writer.WriteEndElement();
+
+        // sheetData
+        writer.WriteStartElement("sheetData", SpreadsheetMlNamespace);
+        foreach (var row in sheetData.Elements<Row>())
+        {
+          writer.WriteStartElement("row", SpreadsheetMlNamespace);
+          if (row.RowIndex != null)
+          {
+            writer.WriteAttributeString("r", row.RowIndex.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          foreach (var cell in row.Elements<Cell>())
+          {
+            writer.WriteStartElement("c", SpreadsheetMlNamespace);
+            if (cell.CellReference != null)
+            {
+              writer.WriteAttributeString("r", cell.CellReference.Value);
+            }
+
+            if (cell.StyleIndex != null)
+            {
+              writer.WriteAttributeString("s", cell.StyleIndex.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (cell.DataType != null)
+            {
+              writer.WriteAttributeString("t", ToCellTypeAttribute(cell.DataType.Value));
+            }
+
+            if (cell.CellValue != null)
+            {
+              writer.WriteStartElement("v", SpreadsheetMlNamespace);
+              writer.WriteString(cell.CellValue.Text);
+              writer.WriteEndElement();
+            }
+
+            if (cell.InlineString != null)
+            {
+              writer.WriteStartElement("is", SpreadsheetMlNamespace);
+              writer.WriteStartElement("t", SpreadsheetMlNamespace);
+              writer.WriteString(cell.InlineString.Text?.Text ?? string.Empty);
+              writer.WriteEndElement();
+              writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement(); // c
+          }
+
+          writer.WriteEndElement(); // row
+        }
+
+        writer.WriteEndElement(); // sheetData
+
+        writer.WriteStartElement("pageMargins", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("left", "0.7");
+        writer.WriteAttributeString("right", "0.7");
+        writer.WriteAttributeString("top", "0.75");
+        writer.WriteAttributeString("bottom", "0.75");
+        writer.WriteAttributeString("header", "0.3");
+        writer.WriteAttributeString("footer", "0.3");
+        writer.WriteEndElement();
+
+        writer.WriteEndElement(); // worksheet
+        writer.WriteEndDocument();
 
         count++;
       }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -65,13 +65,13 @@ namespace SimpleExcelExporter
       // cf. https://issuetracker.google.com/issues/210875597
       using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-      // Order matters : BuildStylesheetSkeleton must run BEFORE WriteWorksheets
-      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex) ;
+      // Order matters: BuildStylesheetSkeleton must run BEFORE WriteWorksheets
+      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex);
       // and both must run BEFORE WriteStyles serializes _stylesheet.
       BuildStylesheetSkeleton();
 
       WriteContentTypes(archive);
-      WritePackageRels(archive);
+      WritePackageRelationships(archive);
       WriteCoreProperties(archive);
       WriteWorkbookRels(archive);
       WriteWorkbook(archive);
@@ -226,7 +226,7 @@ namespace SimpleExcelExporter
       writer.Flush();
     }
 
-    private static void WritePackageRels(ZipArchive archive)
+    private static void WritePackageRelationships(ZipArchive archive)
     {
       var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
       using var stream = entry.Open();
@@ -268,7 +268,7 @@ namespace SimpleExcelExporter
 
       while (objectQueue.Count > 0)
       {
-        (var currentPlayer, var currentPlayerTypePropertyInfos, var currentIteration, var currentParentIndex) = objectQueue.Dequeue();
+        var (currentPlayer, currentPlayerTypePropertyInfos, currentIteration, currentParentIndex) = objectQueue.Dequeue();
 
         foreach (var playerTypePropertyInfo in currentPlayerTypePropertyInfos)
         {
@@ -295,7 +295,7 @@ namespace SimpleExcelExporter
 
               // Add empty cells if needed
               var numberOfEmptyCellToAdd = maxNumberOfElement - childIteration + 1;
-              if (childPlayerType != null && childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
+              if (childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
               {
                 for (var i = 0; i < numberOfEmptyCellToAdd; i++)
                 {
@@ -345,7 +345,7 @@ namespace SimpleExcelExporter
 
       while (objectQueue.Count > 0)
       {
-        (var currentPlayer, var currentPlayerType, var currentPlayerTypePropertyInfos, var currentIteration, var currentParentIndex) = objectQueue.Dequeue();
+        var (currentPlayer, currentPlayerType, currentPlayerTypePropertyInfos, currentIteration, currentParentIndex) = objectQueue.Dequeue();
 
         foreach (var playerTypePropertyInfo in currentPlayerTypePropertyInfos)
         {
@@ -371,7 +371,7 @@ namespace SimpleExcelExporter
 
               // Add empty cells if needed
               var numberOfEmptyCellToAdd = maxNumberOfElement - childIteration + 1;
-              if (childPlayerType != null && childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
+              if (childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
               {
                 for (var i = 0; i < numberOfEmptyCellToAdd; i++)
                 {
@@ -413,7 +413,7 @@ namespace SimpleExcelExporter
             else
             {
               // If the currentPlayer was null when the existing headerCell was added in _headers, then we should update the text.
-              (var headerCellDfn, var textCorrectlySetFlag) = value;
+              var (headerCellDfn, textCorrectlySetFlag) = value;
               if (!textCorrectlySetFlag && currentPlayer != null)
               {
                 _ = _headers.Remove(key);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -481,12 +481,13 @@ namespace SimpleExcelExporter
       }
     }
 
-    private Cell CreateCell(CellDfn cellDfn)
+    private Cell CreateCell(CellDfn cellDfn, uint rowIndex, int columnIndex)
     {
       var stylIndex = CreateOrGetStylIndex(cellDfn);
 
       var cell = new Cell
       {
+        CellReference = $"{ColumnReferenceHelper.ToLetters(columnIndex)}{rowIndex}",
         StyleIndex = stylIndex,
       };
 
@@ -551,12 +552,14 @@ namespace SimpleExcelExporter
       return cell;
     }
 
-    private Row CreateHeaderRowForExcel(IEnumerable<CellDfn> columnHeadings)
+    private Row CreateHeaderRowForExcel(IEnumerable<CellDfn> columnHeadings, uint rowIndex)
     {
-      var row = new Row();
+      var row = new Row { RowIndex = rowIndex };
+      var columnIndex = 1;
       foreach (var cellDfn in columnHeadings)
       {
-        _ = row.AppendChild(CreateCell(cellDfn));
+        _ = row.AppendChild(CreateCell(cellDfn, rowIndex, columnIndex));
+        columnIndex++;
       }
 
       return row;
@@ -636,13 +639,14 @@ namespace SimpleExcelExporter
       }
     }
 
-    private Row GenerateRowForChildPartDetail(RowDfn rowDfn)
+    private Row GenerateRowForChildPartDetail(RowDfn rowDfn, uint rowIndex)
     {
-      var row = new Row();
-
+      var row = new Row { RowIndex = rowIndex };
+      var columnIndex = 1;
       foreach (var cellDfn in rowDfn.Cells)
       {
-        _ = row.AppendChild(CreateCell(cellDfn));
+        _ = row.AppendChild(CreateCell(cellDfn, rowIndex, columnIndex));
+        columnIndex++;
       }
 
       return row;
@@ -651,15 +655,18 @@ namespace SimpleExcelExporter
     private SheetData GenerateSheetDataForDetails(WorksheetDfn worksheet)
     {
       var sheetData1 = new SheetData();
+      var currentRowIndex = 1U;
       if (worksheet.ColumnHeadings.Cells.Count > 0)
       {
-        _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells));
+        _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells, currentRowIndex));
+        currentRowIndex++;
       }
 
       foreach (var row in worksheet.Rows)
       {
-        var partsRows = GenerateRowForChildPartDetail(row);
+        var partsRows = GenerateRowForChildPartDetail(row, currentRowIndex);
         _ = sheetData1.AppendChild(partsRows);
+        currentRowIndex++;
       }
 
       return sheetData1;

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -10,7 +10,6 @@ namespace SimpleExcelExporter
   using System.Text;
   using System.Xml;
   using DocumentFormat.OpenXml;
-  using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
   using SimpleExcelExporter.Annotations;
   using SimpleExcelExporter.Definitions;

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -603,6 +603,71 @@ namespace SimpleExcelExporter
       }
     }
 
+    private void BuildStylesheetSkeleton()
+    {
+      // Number formats (empty — using built-in formats only)
+      var numberingFormats = new NumberingFormats { Count = 0U };
+
+      var fonts = new Fonts { Count = 1U };
+
+      // Font 1
+      var font = new Font
+      {
+        FontSize = new FontSize { Val = 11D },
+        FontName = new FontName { Val = "Calibri" },
+        FontFamilyNumbering = new FontFamilyNumbering { Val = 2 },
+        FontScheme = new FontScheme { Val = FontSchemeValues.Minor },
+      };
+
+      _ = fonts.AppendChild(font);
+
+      // Default Fill
+      var fills = new Fills { Count = 1U };
+      var fill = new Fill { PatternFill = new PatternFill { PatternType = PatternValues.None } };
+      _ = fills.AppendChild(fill);
+
+      // Default Border
+      var borders = new Borders { Count = 1U };
+      var border = new Border
+      {
+        LeftBorder = new LeftBorder(),
+        RightBorder = new RightBorder(),
+        TopBorder = new TopBorder(),
+        BottomBorder = new BottomBorder(),
+        DiagonalBorder = new DiagonalBorder(),
+      };
+      _ = borders.AppendChild(border);
+
+      // CellStyleFormats
+      var cellStyleFormats = new CellStyleFormats { Count = 1U };
+      var cellFormat = new CellFormat { NumberFormatId = 0U, FontId = 0U, FillId = 0U, BorderId = 0U };
+      _ = cellStyleFormats.AppendChild(cellFormat);
+
+      // CellFormats — empty, populated by CreateOrGetStylIndex during worksheet processing
+      var cellFormats = new CellFormats { Count = 0U };
+
+      // CellStyles — Excel requires the "Normal" built-in style
+      var cellStyles = new CellStyles { Count = 1U };
+      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
+
+      // TableStyles — empty but required by strict parsers
+      var tableStyles = new TableStyles
+      {
+        Count = 0U,
+        DefaultTableStyle = "TableStyleMedium9",
+        DefaultPivotStyle = "PivotStyleLight16",
+      };
+
+      _ = _stylesheet.AppendChild(numberingFormats);
+      _ = _stylesheet.AppendChild(fonts);
+      _ = _stylesheet.AppendChild(fills);
+      _ = _stylesheet.AppendChild(borders);
+      _ = _stylesheet.AppendChild(cellStyleFormats);
+      _ = _stylesheet.AppendChild(cellFormats);
+      _ = _stylesheet.AppendChild(cellStyles);
+      _ = _stylesheet.AppendChild(tableStyles);
+    }
+
     private string? BuildText(PropertyInfo playerTypePropertyInfo, Type currentPlayerType, object? currentPlayer)
     {
       var headerAttribute = GetAttributeFrom<HeaderAttribute>(playerTypePropertyInfo);
@@ -1165,6 +1230,58 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
+    private void WriteStyles(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteElement(_stylesheet);
+    }
+
+    private void WriteWorkbook(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+      var workbook = new Workbook();
+      workbook.Append(new BookViews(new WorkbookView()));
+
+      var sheets = new Sheets();
+      _ = workbook.AppendChild(sheets);
+
+      var sheetId = 1U;
+      var rId = 2;
+      foreach (var worksheet in _workbookDfn.Worksheets)
+      {
+        _ = sheets.AppendChild(new Sheet
+        {
+          Name = worksheet.Name,
+          SheetId = sheetId,
+          Id = $"rId{rId}",
+        });
+        sheetId++;
+        rId++;
+      }
+
+      writer.WriteStartDocument(standalone: true);
+
+      var namespaceDeclarations = new List<KeyValuePair<string, string>>
+      {
+        new("r", RelationshipsNamespace),
+      };
+
+      writer.WriteStartElement(workbook, Array.Empty<OpenXmlAttribute>(), namespaceDeclarations);
+      foreach (var child in workbook.ChildElements)
+      {
+        writer.WriteElement(child);
+      }
+
+      writer.WriteEndElement();
+    }
+
     private void WriteWorkbookRels(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
@@ -1198,6 +1315,45 @@ namespace SimpleExcelExporter
 
       writer.WriteEndElement();
       writer.WriteEndDocument();
+    }
+
+    private void WriteWorksheets(ZipArchive archive)
+    {
+      var count = 1U;
+      foreach (var worksheet in _workbookDfn.Worksheets)
+      {
+        var entry = archive.CreateEntry($"xl/worksheets/sheet{count}.xml", CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
+
+        var reference = lastRowIndex == 0U || maxColumnCount == 0
+          ? "A1"
+          : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
+        var sheetDimension = new SheetDimension { Reference = reference };
+
+        var sheetViews = new SheetViews();
+        var sheetView = new SheetView { TabSelected = count == 1U, WorkbookViewId = 0U };
+        var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
+        _ = sheetView.AppendChild(selection);
+        _ = sheetViews.AppendChild(sheetView);
+
+        var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
+        var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
+
+        var worksheetElement = new Worksheet();
+        _ = worksheetElement.AppendChild(sheetDimension);
+        _ = worksheetElement.AppendChild(sheetViews);
+        _ = worksheetElement.AppendChild(sheetFormatProperties);
+        _ = worksheetElement.AppendChild(sheetData);
+        _ = worksheetElement.AppendChild(pageMargins);
+
+        writer.WriteStartDocument(standalone: true);
+        writer.WriteElement(worksheetElement);
+
+        count++;
+      }
     }
   }
 }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -63,7 +63,18 @@ namespace SimpleExcelExporter
         var coreFilePropPart = document.AddCoreFilePropertiesPart();
         using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
         {
-          writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
+          var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+          writer.WriteRaw(
+            $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<cp:coreProperties " +
+            "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+            "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+            "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+            "<dc:creator>SimpleExcelExporter</dc:creator>" +
+            $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+            $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+            "</cp:coreProperties>");
           writer.Flush();
         }
 

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -73,7 +73,7 @@ namespace SimpleExcelExporter
       WriteContentTypes(archive);
       WritePackageRelationships(archive);
       WriteCoreProperties(archive);
-      WriteWorkbookRels(archive);
+      WriteWorkbookRelationships(archive);
       WriteWorkbook(archive);
       WriteWorksheets(archive);
       WriteStyles(archive);
@@ -1108,7 +1108,7 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
-    private void WriteWorkbookRels(ZipArchive archive)
+    private void WriteWorkbookRelationships(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
       using var stream = entry.Open();

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -813,6 +813,9 @@ namespace SimpleExcelExporter
 
     private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)
     {
+      // Number formats (empty — using built-in formats only)
+      var numberingFormats = new NumberingFormats { Count = 0U };
+
       var fonts = new Fonts { Count = 1U };
 
       // Font 1
@@ -851,11 +854,26 @@ namespace SimpleExcelExporter
       // CellFormats
       var cellFormats = new CellFormats { Count = 0U };
 
+      // CellStyles — Excel requires the "Normal" built-in style
+      var cellStyles = new CellStyles { Count = 1U };
+      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
+
+      // TableStyles — empty but required by strict parsers
+      var tableStyles = new TableStyles
+      {
+        Count = 0U,
+        DefaultTableStyle = "TableStyleMedium9",
+        DefaultPivotStyle = "PivotStyleLight16",
+      };
+
+      _ = _stylesheet.AppendChild(numberingFormats);
       _ = _stylesheet.AppendChild(fonts);
       _ = _stylesheet.AppendChild(fills);
       _ = _stylesheet.AppendChild(borders);
       _ = _stylesheet.AppendChild(cellStyleFormats);
       _ = _stylesheet.AppendChild(cellFormats);
+      _ = _stylesheet.AppendChild(cellStyles);
+      _ = _stylesheet.AppendChild(tableStyles);
 
       workbookStylesPart.Stylesheet = _stylesheet;
     }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -753,14 +753,15 @@ namespace SimpleExcelExporter
       var sheets = new Sheets();
       _ = workbook.AppendChild(sheets);
 
-      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId3");
+      // Styles first, then worksheets — rId2 reserved for styles, rId3+ for sheets
+      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId2");
       GenerateWorkbookStylesPartContent(workbookStylesPart1);
 
       // Thank you https://stackoverflow.com/questions/9120544/openxml-multiple-sheets
       var count = 1U;
       foreach (var worksheet in _workbookDfn.Worksheets)
       {
-        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>($"rId{count + 2}");  // rId3, rId4, ...
         var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
         _ = sheets.AppendChild(sheet);
         var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -101,6 +101,12 @@ namespace SimpleExcelExporter
     [GeneratedRegex("Target=\"/([^\"]+)\"")]
     private static partial Regex AbsoluteTargetRegex();
 
+    [GeneratedRegex("Id=\"R[0-9a-fA-F]{16}\"")]
+    private static partial Regex GuidIdRegex();
+
+    [GeneratedRegex("Id=\"rId(\\d+)\"")]
+    private static partial Regex ExistingRelIdRegex();
+
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
       var headerCellDfn = new CellDfn(text, index: index);
@@ -280,6 +286,24 @@ namespace SimpleExcelExporter
           }
 
           return $"Target=\"{absTarget}\"";
+        });
+
+        // Normalize SDK-generated GUID-style IDs (Id="R<16 hex>") to sequential rIdN
+        var maxExistingId = 0;
+        foreach (Match existing in ExistingRelIdRegex().Matches(content))
+        {
+          var num = int.Parse(existing.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+          if (num > maxExistingId)
+          {
+            maxExistingId = num;
+          }
+        }
+
+        var nextId = maxExistingId;
+        content = GuidIdRegex().Replace(content, _ =>
+        {
+          nextId++;
+          return $"Id=\"rId{nextId}\"";
         });
 
         entry.Delete();

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -7,6 +7,7 @@ namespace SimpleExcelExporter
   using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
+  using System.Text.RegularExpressions;
   using System.Xml;
   using System.Xml.Linq;
   using DocumentFormat.OpenXml;
@@ -16,7 +17,7 @@ namespace SimpleExcelExporter
   using SimpleExcelExporter.Definitions;
   using SimpleExcelExporter.Resources;
 
-  public class SpreadsheetWriter
+  public partial class SpreadsheetWriter
   {
     private readonly Dictionary<string, Attribute?> _cachedAttributes = [];
 
@@ -88,8 +89,14 @@ namespace SimpleExcelExporter
       FixNamespacePrefixes(buffer);
 
       buffer.Position = 0;
+      FixRelationshipTargets(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
+
+    [GeneratedRegex("Target=\"/([^\"]+)\"")]
+    private static partial Regex AbsoluteTargetRegex();
 
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
@@ -229,6 +236,48 @@ namespace SimpleExcelExporter
           .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
           .Replace("<x:", "<", StringComparison.Ordinal)
           .Replace("</x:", "</", StringComparison.Ordinal);
+
+        entry.Delete();
+        var newEntry = archive.CreateEntry(entry.FullName);
+        using var writerStream = newEntry.Open();
+        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+      }
+    }
+
+    private static void FixRelationshipTargets(MemoryStream buffer)
+    {
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+
+      var relsEntries = archive.Entries
+        .Where(e => e.FullName.EndsWith(".rels", StringComparison.Ordinal))
+        .ToList();
+
+      foreach (var entry in relsEntries)
+      {
+        string content;
+        using (var entryStream = entry.Open())
+        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+        {
+          content = reader.ReadToEnd();
+        }
+
+        // Compute base directory: for "_rels/.rels" base is ""; for "xl/_rels/workbook.xml.rels" base is "xl/"
+        var relsIndex = entry.FullName.LastIndexOf("_rels/", StringComparison.Ordinal);
+        var baseDir = relsIndex == 0 ? string.Empty : entry.FullName.Substring(0, relsIndex);
+
+        // Transform absolute targets to relative
+        // Strategy: replace Target="/x/y/z" with the part relative to baseDir
+        content = AbsoluteTargetRegex().Replace(content, match =>
+        {
+          var absTarget = match.Groups[1].Value;
+          if (baseDir.Length > 0 && absTarget.StartsWith(baseDir, StringComparison.Ordinal))
+          {
+            return $"Target=\"{absTarget.Substring(baseDir.Length)}\"";
+          }
+
+          return $"Target=\"{absTarget}\"";
+        });
 
         entry.Delete();
         var newEntry = archive.CreateEntry(entry.FullName);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -4,9 +4,11 @@ namespace SimpleExcelExporter
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
+  using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
   using System.Xml;
+  using System.Xml.Linq;
   using DocumentFormat.OpenXml;
   using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
@@ -50,20 +52,29 @@ namespace SimpleExcelExporter
 
     public void Write()
     {
-      using var document = SpreadsheetDocument.Create(_stream, SpreadsheetDocumentType.Workbook);
+      using var buffer = new MemoryStream();
 
       // Adding core file properties is mandatory to avoid a problem with Google Spreadsheet transforming from XLSX to XLSM.
       // cf. https://stackoverflow.com/questions/70319867/avoid-google-spreadsheet-to-convert-an-xlsx-file-created-by-open-xml-sdk-to-xlsm
       // cf. https://github.com/OfficeDev/Open-XML-SDK/issues/1093
       // cf. https://issuetracker.google.com/issues/210875597
-      var coreFilePropPart = document.AddCoreFilePropertiesPart();
-      using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
+      using (var document = SpreadsheetDocument.Create(buffer, SpreadsheetDocumentType.Workbook))
       {
-        writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
-        writer.Flush();
+        var coreFilePropPart = document.AddCoreFilePropertiesPart();
+        using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
+        {
+          writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
+          writer.Flush();
+        }
+
+        CreatePartsForExcel(document);
       }
 
-      CreatePartsForExcel(document);
+      buffer.Position = 0;
+      FixContentTypesXml(buffer);
+
+      buffer.Position = 0;
+      buffer.CopyTo(_stream);
     }
 
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
@@ -116,6 +127,60 @@ namespace SimpleExcelExporter
       }
 
       rowDfn.Cells.Add(cellDfn);
+    }
+
+    private static void FixContentTypesXml(MemoryStream buffer)
+    {
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+      var entry = archive.GetEntry("[Content_Types].xml");
+      if (entry == null)
+      {
+        return;
+      }
+
+      XDocument doc;
+      using (var entryStream = entry.Open())
+      {
+        doc = XDocument.Load(entryStream);
+      }
+
+      var ns = XNamespace.Get("http://schemas.openxmlformats.org/package/2006/content-types");
+      var root = doc.Root!;
+
+      var xmlDefault = root.Elements(ns + "Default")
+        .FirstOrDefault(d => (string?)d.Attribute("Extension") == "xml");
+
+      if (xmlDefault != null && (string?)xmlDefault.Attribute("ContentType") != "application/xml")
+      {
+        var displacedContentType = (string?)xmlDefault.Attribute("ContentType");
+        var displacedPartName = displacedContentType switch
+        {
+          "application/vnd.openxmlformats-package.core-properties+xml" => "/docProps/core.xml",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" => "/xl/workbook.xml",
+          _ => null,
+        };
+
+        if (displacedPartName != null)
+        {
+          var alreadyHasOverride = root.Elements(ns + "Override")
+            .Any(o => (string?)o.Attribute("PartName") == displacedPartName);
+
+          if (!alreadyHasOverride)
+          {
+            root.Add(new XElement(
+              ns + "Override",
+              new XAttribute("PartName", displacedPartName),
+              new XAttribute("ContentType", displacedContentType!)));
+          }
+        }
+
+        xmlDefault.SetAttributeValue("ContentType", "application/xml");
+      }
+
+      entry.Delete();
+      var newEntry = archive.CreateEntry("[Content_Types].xml");
+      using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+      doc.Save(entryWriter);
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -566,8 +566,8 @@ namespace SimpleExcelExporter
 
       if (cellDfn.Value == null)
       {
-        cell.CellValue = new CellValue(string.Empty);
-        cell.DataType = new EnumValue<CellValues>(CellValues.String);
+        cell.InlineString = new InlineString { Text = new Text(string.Empty) };
+        cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is DateTime dateTimeValue)
       {
@@ -608,8 +608,8 @@ namespace SimpleExcelExporter
       else if (cellDfn.Value is string stringValue)
       {
         stringValue = XmlStringHelper.Sanitize(stringValue);
-        cell.CellValue = new CellValue(stringValue);
-        cell.DataType = new EnumValue<CellValues>(CellValues.String);
+        cell.InlineString = new InlineString { Text = new Text(stringValue) };
+        cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is TimeSpan timeSpanValue)
       {

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -74,6 +74,9 @@ namespace SimpleExcelExporter
       FixContentTypesXml(buffer);
 
       buffer.Position = 0;
+      FixNamespacePrefixes(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
 
@@ -181,6 +184,47 @@ namespace SimpleExcelExporter
       var newEntry = archive.CreateEntry("[Content_Types].xml");
       using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
       doc.Save(entryWriter);
+    }
+
+    private static void FixNamespacePrefixes(MemoryStream buffer)
+    {
+      const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+      var prefixedDeclaration = $"xmlns:x=\"{SpreadsheetMlNamespace}\"";
+      var defaultDeclaration = $"xmlns=\"{SpreadsheetMlNamespace}\"";
+
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+
+      var entriesToFix = archive.Entries
+        .Where(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal)
+          && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
+          && !e.FullName.Contains("_rels/", StringComparison.Ordinal))
+        .ToList();
+
+      foreach (var entry in entriesToFix)
+      {
+        string content;
+        using (var entryStream = entry.Open())
+        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+        {
+          content = reader.ReadToEnd();
+        }
+
+        if (!content.Contains(prefixedDeclaration, StringComparison.Ordinal))
+        {
+          continue;
+        }
+
+        content = content
+          .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
+          .Replace("<x:", "<", StringComparison.Ordinal)
+          .Replace("</x:", "</", StringComparison.Ordinal);
+
+        entry.Delete();
+        var newEntry = archive.CreateEntry(entry.FullName);
+        using var writerStream = newEntry.Open();
+        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+      }
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -8,9 +8,7 @@ namespace SimpleExcelExporter
   using System.Linq;
   using System.Reflection;
   using System.Text;
-  using System.Text.RegularExpressions;
   using System.Xml;
-  using System.Xml.Linq;
   using DocumentFormat.OpenXml;
   using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
@@ -18,7 +16,7 @@ namespace SimpleExcelExporter
   using SimpleExcelExporter.Definitions;
   using SimpleExcelExporter.Resources;
 
-  public partial class SpreadsheetWriter
+  public class SpreadsheetWriter
   {
     private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
 
@@ -82,15 +80,6 @@ namespace SimpleExcelExporter
       WriteStyles(archive);
     }
 
-    [GeneratedRegex("Target=\"/([^\"]+)\"")]
-    private static partial Regex AbsoluteTargetRegex();
-
-    [GeneratedRegex("Id=\"R[0-9a-fA-F]{16}\"")]
-    private static partial Regex GuidIdRegex();
-
-    [GeneratedRegex("Id=\"rId(\\d+)\"")]
-    private static partial Regex ExistingRelIdRegex();
-
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
       var headerCellDfn = new CellDfn(text, index: index);
@@ -141,237 +130,6 @@ namespace SimpleExcelExporter
       }
 
       rowDfn.Cells.Add(cellDfn);
-    }
-
-    private static void FixContentTypesXml(MemoryStream buffer)
-    {
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-      var entry = archive.GetEntry("[Content_Types].xml");
-      if (entry == null)
-      {
-        return;
-      }
-
-      XDocument doc;
-      using (var entryStream = entry.Open())
-      {
-        doc = XDocument.Load(entryStream);
-      }
-
-      var ns = XNamespace.Get("http://schemas.openxmlformats.org/package/2006/content-types");
-      var root = doc.Root!;
-
-      var xmlDefault = root.Elements(ns + "Default")
-        .FirstOrDefault(d => (string?)d.Attribute("Extension") == "xml");
-
-      if (xmlDefault != null && (string?)xmlDefault.Attribute("ContentType") != "application/xml")
-      {
-        var displacedContentType = (string?)xmlDefault.Attribute("ContentType");
-        var displacedPartName = displacedContentType switch
-        {
-          "application/vnd.openxmlformats-package.core-properties+xml" => "/docProps/core.xml",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" => "/xl/workbook.xml",
-          _ => null,
-        };
-
-        if (displacedPartName != null)
-        {
-          var alreadyHasOverride = root.Elements(ns + "Override")
-            .Any(o => (string?)o.Attribute("PartName") == displacedPartName);
-
-          if (!alreadyHasOverride)
-          {
-            root.Add(new XElement(
-              ns + "Override",
-              new XAttribute("PartName", displacedPartName),
-              new XAttribute("ContentType", displacedContentType!)));
-          }
-        }
-
-        xmlDefault.SetAttributeValue("ContentType", "application/xml");
-      }
-
-      entry.Delete();
-      var newEntry = archive.CreateEntry("[Content_Types].xml");
-      using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-      doc.Save(entryWriter);
-    }
-
-    private static void FixNamespacePrefixes(MemoryStream buffer)
-    {
-      const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-      var prefixedDeclaration = $"xmlns:x=\"{SpreadsheetMlNamespace}\"";
-      var defaultDeclaration = $"xmlns=\"{SpreadsheetMlNamespace}\"";
-
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-
-      var entriesToFix = archive.Entries
-        .Where(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal)
-          && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
-          && !e.FullName.Contains("_rels/", StringComparison.Ordinal))
-        .ToList();
-
-      foreach (var entry in entriesToFix)
-      {
-        string content;
-        using (var entryStream = entry.Open())
-        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-        {
-          content = reader.ReadToEnd();
-        }
-
-        if (!content.Contains(prefixedDeclaration, StringComparison.Ordinal))
-        {
-          continue;
-        }
-
-        content = content
-          .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
-          .Replace("<x:", "<", StringComparison.Ordinal)
-          .Replace("</x:", "</", StringComparison.Ordinal);
-
-        entry.Delete();
-        var newEntry = archive.CreateEntry(entry.FullName);
-        using var writerStream = newEntry.Open();
-        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        writer.Write(content);
-      }
-    }
-
-    private static void FixRelationshipTargets(MemoryStream buffer)
-    {
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-
-      var relsEntries = archive.Entries
-        .Where(e => e.FullName.EndsWith(".rels", StringComparison.Ordinal))
-        .ToList();
-
-      foreach (var entry in relsEntries)
-      {
-        string content;
-        using (var entryStream = entry.Open())
-        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-        {
-          content = reader.ReadToEnd();
-        }
-
-        // Compute base directory: for "_rels/.rels" base is ""; for "xl/_rels/workbook.xml.rels" base is "xl/"
-        var relsIndex = entry.FullName.LastIndexOf("_rels/", StringComparison.Ordinal);
-        var baseDir = relsIndex == 0 ? string.Empty : entry.FullName.Substring(0, relsIndex);
-
-        // Transform absolute targets to relative
-        // Strategy: replace Target="/x/y/z" with the part relative to baseDir
-        content = AbsoluteTargetRegex().Replace(content, match =>
-        {
-          var absTarget = match.Groups[1].Value;
-          if (baseDir.Length > 0 && absTarget.StartsWith(baseDir, StringComparison.Ordinal))
-          {
-            return $"Target=\"{absTarget.Substring(baseDir.Length)}\"";
-          }
-
-          return $"Target=\"{absTarget}\"";
-        });
-
-        // Normalize SDK-generated GUID-style IDs (Id="R<16 hex>") to sequential rIdN
-        var maxExistingId = 0;
-        foreach (Match existing in ExistingRelIdRegex().Matches(content))
-        {
-          var num = int.Parse(existing.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
-          if (num > maxExistingId)
-          {
-            maxExistingId = num;
-          }
-        }
-
-        var nextId = maxExistingId;
-        content = GuidIdRegex().Replace(content, _ =>
-        {
-          nextId++;
-          return $"Id=\"rId{nextId}\"";
-        });
-
-        entry.Delete();
-        var newEntry = archive.CreateEntry(entry.FullName);
-        using var writerStream = newEntry.Open();
-        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        writer.Write(content);
-      }
-    }
-
-    private static void FixWorkbookNamespaceDeclaration(MemoryStream buffer)
-    {
-      const string RelsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-      const string MainNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-      var relsDeclaration = $" xmlns:r=\"{RelsNamespace}\"";
-
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-      var entry = archive.GetEntry("xl/workbook.xml");
-      if (entry == null)
-      {
-        return;
-      }
-
-      string content;
-      using (var entryStream = entry.Open())
-      using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-      {
-        content = reader.ReadToEnd();
-      }
-
-      // If xmlns:r is already on <workbook>, nothing to do
-      var workbookTagEnd = content.IndexOf('>', content.IndexOf("<workbook", StringComparison.Ordinal));
-      var workbookTag = content.Substring(0, workbookTagEnd + 1);
-      if (workbookTag.Contains("xmlns:r=", StringComparison.Ordinal))
-      {
-        return;
-      }
-
-      // Remove xmlns:r declarations anywhere in the document
-      content = content.Replace(relsDeclaration, string.Empty, StringComparison.Ordinal);
-
-      // Add xmlns:r to the <workbook> element
-      content = content.Replace(
-        $"<workbook xmlns=\"{MainNamespace}\"",
-        $"<workbook xmlns:r=\"{RelsNamespace}\" xmlns=\"{MainNamespace}\"",
-        StringComparison.Ordinal);
-
-      entry.Delete();
-      var newEntry = archive.CreateEntry(entry.FullName);
-      using var writerStream = newEntry.Open();
-      using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-      writer.Write(content);
-    }
-
-    private static void GenerateWorksheetPartContent(
-      WorksheetPart worksheetPart,
-      SheetData sheetData,
-      bool tabSelectedFlag,
-      int maxColumnCount,
-      uint lastRowIndex)
-    {
-      var worksheet = new Worksheet();
-      var reference = lastRowIndex == 0U || maxColumnCount == 0
-        ? "A1"
-        : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
-      var sheetDimension = new SheetDimension { Reference = reference };
-
-      var sheetViews = new SheetViews();
-
-      var sheetView = new SheetView { TabSelected = tabSelectedFlag, WorkbookViewId = 0U };
-      var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
-
-      _ = sheetView.AppendChild(selection);
-
-      _ = sheetViews.AppendChild(sheetView);
-      var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
-
-      var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
-      _ = worksheet.AppendChild(sheetDimension);
-      _ = worksheet.AppendChild(sheetViews);
-      _ = worksheet.AppendChild(sheetFormatProperties);
-      _ = worksheet.AppendChild(sheetData);
-      _ = worksheet.AppendChild(pageMargins);
-      worksheetPart.Worksheet = worksheet;
     }
 
     private static List<int> ManageIndex(int iteration, List<int>? parentIndex, IndexAttribute? indexAttribute)
@@ -1021,32 +779,6 @@ namespace SimpleExcelExporter
       return index;
     }
 
-    private void CreatePartsForExcel(SpreadsheetDocument document)
-    {
-      var workbookPart = document.AddWorkbookPart();
-      var workbook = new Workbook();
-      workbook.Append(new BookViews(new WorkbookView()));
-      workbookPart.Workbook = workbook;
-      var sheets = new Sheets();
-      _ = workbook.AppendChild(sheets);
-
-      // Styles first, then worksheets — rId2 reserved for styles, rId3+ for sheets
-      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId2");
-      GenerateWorkbookStylesPartContent(workbookStylesPart1);
-
-      // Thank you https://stackoverflow.com/questions/9120544/openxml-multiple-sheets
-      var count = 1U;
-      foreach (var worksheet in _workbookDfn.Worksheets)
-      {
-        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>($"rId{count + 2}");  // rId3, rId4, ...
-        var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
-        _ = sheets.AppendChild(sheet);
-        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
-        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U, maxColumnCount, lastRowIndex);
-        count++;
-      }
-    }
-
     private Row GenerateRowForChildPartDetail(RowDfn rowDfn, uint rowIndex)
     {
       var row = new Row { RowIndex = rowIndex };
@@ -1087,73 +819,6 @@ namespace SimpleExcelExporter
 
       var lastRowIndex = currentRowIndex - 1U;
       return (sheetData1, maxColumnCount, lastRowIndex);
-    }
-
-    private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)
-    {
-      // Number formats (empty — using built-in formats only)
-      var numberingFormats = new NumberingFormats { Count = 0U };
-
-      var fonts = new Fonts { Count = 1U };
-
-      // Font 1
-      var font = new Font
-      {
-        FontSize = new FontSize { Val = 11D },
-        FontName = new FontName { Val = "Calibri" },
-        FontFamilyNumbering = new FontFamilyNumbering { Val = 2 },
-        FontScheme = new FontScheme { Val = FontSchemeValues.Minor },
-      };
-
-      _ = fonts.AppendChild(font);
-
-      // Default Fill
-      var fills = new Fills { Count = 1U };
-      var fill = new Fill { PatternFill = new PatternFill { PatternType = PatternValues.None } };
-      _ = fills.AppendChild(fill);
-
-      // Default Border
-      var borders = new Borders { Count = 1U };
-      var border = new Border
-      {
-        LeftBorder = new LeftBorder(),
-        RightBorder = new RightBorder(),
-        TopBorder = new TopBorder(),
-        BottomBorder = new BottomBorder(),
-        DiagonalBorder = new DiagonalBorder(),
-      };
-      _ = borders.AppendChild(border);
-
-      // CellStyleFormats
-      var cellStyleFormats = new CellStyleFormats { Count = 1U };
-      var cellFormat = new CellFormat { NumberFormatId = 0U, FontId = 0U, FillId = 0U, BorderId = 0U };
-      _ = cellStyleFormats.AppendChild(cellFormat);
-
-      // CellFormats
-      var cellFormats = new CellFormats { Count = 0U };
-
-      // CellStyles — Excel requires the "Normal" built-in style
-      var cellStyles = new CellStyles { Count = 1U };
-      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
-
-      // TableStyles — empty but required by strict parsers
-      var tableStyles = new TableStyles
-      {
-        Count = 0U,
-        DefaultTableStyle = "TableStyleMedium9",
-        DefaultPivotStyle = "PivotStyleLight16",
-      };
-
-      _ = _stylesheet.AppendChild(numberingFormats);
-      _ = _stylesheet.AppendChild(fonts);
-      _ = _stylesheet.AppendChild(fills);
-      _ = _stylesheet.AppendChild(borders);
-      _ = _stylesheet.AppendChild(cellStyleFormats);
-      _ = _stylesheet.AppendChild(cellFormats);
-      _ = _stylesheet.AppendChild(cellStyles);
-      _ = _stylesheet.AppendChild(tableStyles);
-
-      workbookStylesPart.Stylesheet = _stylesheet;
     }
 
     private T? GetAttributeFrom<T>(PropertyInfo propertyInfo)

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -118,10 +118,18 @@ namespace SimpleExcelExporter
       rowDfn.Cells.Add(cellDfn);
     }
 
-    private static void GenerateWorksheetPartContent(WorksheetPart worksheetPart, SheetData sheetData, bool tabSelectedFlag)
+    private static void GenerateWorksheetPartContent(
+      WorksheetPart worksheetPart,
+      SheetData sheetData,
+      bool tabSelectedFlag,
+      int maxColumnCount,
+      uint lastRowIndex)
     {
       var worksheet = new Worksheet();
-      var sheetDimension = new SheetDimension { Reference = "A1" };
+      var reference = lastRowIndex == 0U || maxColumnCount == 0
+        ? "A1"
+        : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
+      var sheetDimension = new SheetDimension { Reference = reference };
 
       var sheetViews = new SheetViews();
 
@@ -633,8 +641,8 @@ namespace SimpleExcelExporter
         var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
         var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
         _ = sheets.AppendChild(sheet);
-        var sheetData = GenerateSheetDataForDetails(worksheet);
-        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U);
+        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
+        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U, maxColumnCount, lastRowIndex);
         count++;
       }
     }
@@ -652,13 +660,16 @@ namespace SimpleExcelExporter
       return row;
     }
 
-    private SheetData GenerateSheetDataForDetails(WorksheetDfn worksheet)
+    private (SheetData SheetData, int MaxColumnCount, uint LastRowIndex) GenerateSheetDataForDetails(WorksheetDfn worksheet)
     {
       var sheetData1 = new SheetData();
       var currentRowIndex = 1U;
+      var maxColumnCount = 0;
+
       if (worksheet.ColumnHeadings.Cells.Count > 0)
       {
         _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells, currentRowIndex));
+        maxColumnCount = worksheet.ColumnHeadings.Cells.Count;
         currentRowIndex++;
       }
 
@@ -666,10 +677,16 @@ namespace SimpleExcelExporter
       {
         var partsRows = GenerateRowForChildPartDetail(row, currentRowIndex);
         _ = sheetData1.AppendChild(partsRows);
+        if (row.Cells.Count > maxColumnCount)
+        {
+          maxColumnCount = row.Cells.Count;
+        }
+
         currentRowIndex++;
       }
 
-      return sheetData1;
+      var lastRowIndex = currentRowIndex - 1U;
+      return (sheetData1, maxColumnCount, lastRowIndex);
     }
 
     private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)

--- a/test/SimpleExcelExporterTests/ColumnReferenceHelperTest.cs
+++ b/test/SimpleExcelExporterTests/ColumnReferenceHelperTest.cs
@@ -1,0 +1,32 @@
+namespace SimpleExcelExporter.Tests
+{
+  using NUnit.Framework;
+
+  [TestFixture]
+  public class ColumnReferenceHelperTest
+  {
+    [TestCase(1, "A")]
+    [TestCase(2, "B")]
+    [TestCase(25, "Y")]
+    [TestCase(26, "Z")]
+    [TestCase(27, "AA")]
+    [TestCase(28, "AB")]
+    [TestCase(52, "AZ")]
+    [TestCase(53, "BA")]
+    [TestCase(702, "ZZ")]
+    [TestCase(703, "AAA")]
+    public void ToLetters_ConvertsOneIndexedColumnNumberToA1Letters(int columnIndex, string expected)
+    {
+      var result = ColumnReferenceHelper.ToLetters(columnIndex);
+
+      Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ToLetters_ThrowsForZeroOrNegative()
+    {
+      Assert.Throws<System.ArgumentOutOfRangeException>(() => ColumnReferenceHelper.ToLetters(0));
+      Assert.Throws<System.ArgumentOutOfRangeException>(() => ColumnReferenceHelper.ToLetters(-1));
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -3,6 +3,7 @@ namespace SimpleExcelExporter.Tests
   using System.IO;
   using System.IO.Compression;
   using System.Linq;
+  using System.Text;
   using System.Xml.Linq;
   using NUnit.Framework;
   using SimpleExcelExporter.Tests.Preparators.Definitions;
@@ -77,6 +78,48 @@ namespace SimpleExcelExporter.Tests
 
       var overrideForSheet1 = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/worksheets/sheet1.xml");
       Assert.That(overrideForSheet1, Is.Not.Null, "Expected a <Override> for /xl/worksheets/sheet1.xml");
+    }
+
+    [Test]
+    public void StringCells_UseInlineString_NotStr()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var strCells = sheetXml.Descendants(ns + "c")
+        .Where(c => (string?)c.Attribute("t") == "str")
+        .ToList();
+      Assert.That(strCells, Is.Empty, "No cell should use t=\"str\" (reserved for formula results)");
+
+      var inlineStrCells = sheetXml.Descendants(ns + "c")
+        .Where(c => (string?)c.Attribute("t") == "inlineStr")
+        .ToList();
+      Assert.That(inlineStrCells, Is.Not.Empty, "String cells should use t=\"inlineStr\"");
+
+      // Verify inlineStr cells have <is><t>...</t></is> structure, not <v>
+      foreach (var cell in inlineStrCells)
+      {
+        var inlineString = cell.Element(ns + "is");
+        Assert.That(inlineString, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is> element");
+        var text = inlineString!.Element(ns + "t");
+        Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
+        Assert.That(cell.Element(ns + "v"), Is.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must NOT have <v> element");
+      }
+    }
+
+    [Test]
+    public void Worksheet_UsesDefaultNamespace()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
+      Assert.That(entry, Is.Not.Null, "Missing xl/worksheets/sheet1.xml");
+      using var stream = entry!.Open();
+      using var reader = new StreamReader(stream, Encoding.UTF8);
+      var content = reader.ReadToEnd();
+
+      Assert.That(content, Does.Not.Contain("xmlns:x="), "Worksheet should use default namespace, not x: prefix");
+      Assert.That(content, Does.Contain("xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""), "Worksheet should declare SpreadsheetML namespace as default");
+      Assert.That(content, Does.Not.Contain("<x:"), "Worksheet should not use x: prefix on any element");
     }
 
     private static XDocument LoadContentTypesXml()

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -1,0 +1,109 @@
+namespace SimpleExcelExporter.Tests
+{
+  using System.IO;
+  using System.IO.Compression;
+  using System.Linq;
+  using System.Xml.Linq;
+  using NUnit.Framework;
+  using SimpleExcelExporter.Tests.Preparators.Definitions;
+
+  [TestFixture]
+  public class SpreadSheetWriterOoxmlComplianceTest
+  {
+    private const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    [Test]
+    public void RowsAndCells_HaveReferenceAttributes()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var rows = sheetXml.Descendants(ns + "row").ToList();
+      Assert.That(rows, Is.Not.Empty, "Expected at least one <row> element");
+
+      uint expectedRowIndex = 1U;
+      foreach (var row in rows)
+      {
+        var rowRef = row.Attribute("r");
+        Assert.That(rowRef, Is.Not.Null, $"Row at position {expectedRowIndex} is missing the 'r' attribute");
+        Assert.That(rowRef!.Value, Is.EqualTo(expectedRowIndex.ToString()), "Row 'r' attribute should be 1-indexed and contiguous");
+
+        var columnIndex = 1;
+        foreach (var cell in row.Elements(ns + "c"))
+        {
+          var cellRef = cell.Attribute("r");
+          Assert.That(cellRef, Is.Not.Null, $"Cell at row {expectedRowIndex} column {columnIndex} is missing the 'r' attribute");
+          var expected = $"{ColumnReferenceHelper.ToLetters(columnIndex)}{expectedRowIndex}";
+          Assert.That(cellRef!.Value, Is.EqualTo(expected), $"Cell reference mismatch at row {expectedRowIndex} column {columnIndex}");
+          columnIndex++;
+        }
+
+        expectedRowIndex++;
+      }
+    }
+
+    [Test]
+    public void SheetDimension_MatchesUsedRange()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      // Fixture FirstFirstWithCollections: 7 columns (A..G), 1 header row + 3 data rows = A1:G4
+      var dimension = sheetXml.Descendants(ns + "dimension").SingleOrDefault();
+      Assert.That(dimension, Is.Not.Null, "Expected a <dimension> element in the worksheet");
+      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:G4"));
+    }
+
+    [Test]
+    public void ContentTypes_DefaultXmlExtension_IsGenericApplicationXml()
+    {
+      var contentTypesXml = LoadContentTypesXml();
+      var ns = XNamespace.Get(ContentTypesNamespace);
+
+      var defaultXml = contentTypesXml.Descendants(ns + "Default").SingleOrDefault(d => (string?)d.Attribute("Extension") == "xml");
+      Assert.That(defaultXml, Is.Not.Null, "Expected a <Default Extension='xml'> entry");
+      Assert.That(defaultXml!.Attribute("ContentType")?.Value, Is.EqualTo("application/xml"), "Default xml extension must be generic application/xml");
+
+      var overrides = contentTypesXml.Descendants(ns + "Override").ToList();
+      var overrideForCore = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/docProps/core.xml");
+      Assert.That(overrideForCore, Is.Not.Null, "Expected a <Override> for /docProps/core.xml");
+      Assert.That(overrideForCore!.Attribute("ContentType")?.Value, Is.EqualTo("application/vnd.openxmlformats-package.core-properties+xml"));
+
+      var overrideForWorkbook = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/workbook.xml");
+      Assert.That(overrideForWorkbook, Is.Not.Null, "Expected a <Override> for /xl/workbook.xml");
+
+      var overrideForSheet1 = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/worksheets/sheet1.xml");
+      Assert.That(overrideForSheet1, Is.Not.Null, "Expected a <Override> for /xl/worksheets/sheet1.xml");
+    }
+
+    private static XDocument LoadContentTypesXml()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("[Content_Types].xml");
+      Assert.That(entry, Is.Not.Null, "Missing [Content_Types].xml in the generated package");
+      using var stream = entry!.Open();
+      return XDocument.Load(stream);
+    }
+
+    private static XDocument LoadSheetXml()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
+      Assert.That(entry, Is.Not.Null, "Missing xl/worksheets/sheet1.xml in the generated package");
+      using var stream = entry!.Open();
+      return XDocument.Load(stream);
+    }
+
+    private static ZipArchive GenerateAndOpenXlsxArchive()
+    {
+      var workbook = WorkbookDfnPreparator.FirstFirstWithCollections();
+      var memory = new MemoryStream();
+      var writer = new SpreadsheetWriter(memory, workbook);
+      writer.Write();
+      memory.Position = 0;
+      return new ZipArchive(memory, ZipArchiveMode.Read, leaveOpen: false);
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -96,14 +96,16 @@ namespace SimpleExcelExporter.Tests
         .ToList();
       Assert.That(inlineStrCells, Is.Not.Empty, "String cells should use t=\"inlineStr\"");
 
-      // Verify inlineStr cells have <is><t>...</t></is> structure, not <v>
+      // Verify inlineStr cells: non-empty ones must have <is><t>...</t></is>, none should have <v>
       foreach (var cell in inlineStrCells)
       {
-        var inlineString = cell.Element(ns + "is");
-        Assert.That(inlineString, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is> element");
-        var text = inlineString!.Element(ns + "t");
-        Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
         Assert.That(cell.Element(ns + "v"), Is.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must NOT have <v> element");
+        var inlineString = cell.Element(ns + "is");
+        if (inlineString != null)
+        {
+          var text = inlineString.Element(ns + "t");
+          Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
+        }
       }
     }
 

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -50,10 +50,11 @@ namespace SimpleExcelExporter.Tests
       var sheetXml = LoadSheetXml();
       var ns = XNamespace.Get(SpreadsheetMlNamespace);
 
-      // Fixture FirstFirstWithCollections: 7 columns (A..G), 1 header row + 3 data rows = A1:G4
+      // Fixture FirstFirstWithCollections: header has 7 columns (A..G) but row3 has 8 cells (A..H).
+      // maxColumnCount = max(7, 7, 7, 8) = 8 → used range is A1:H4.
       var dimension = sheetXml.Descendants(ns + "dimension").SingleOrDefault();
       Assert.That(dimension, Is.Not.Null, "Expected a <dimension> element in the worksheet");
-      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:G4"));
+      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:H4"));
     }
 
     [Test]

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
@@ -137,12 +137,12 @@ namespace SimpleExcelExporter.Tests
 
       var workbookPart = spreadsheetDocument.WorkbookPart;
       var worksheetsPart = workbookPart!.WorksheetParts.First();
-      var sheetData = worksheetsPart.Worksheet.GetFirstChild<SheetData>();
+      var sheetData = worksheetsPart.Worksheet!.GetFirstChild<SheetData>();
       var rows = sheetData!.Descendants<Row>().ToList();
       var cells = rows[0].Descendants<Cell>();
 
       Assert.That(workbookPart.Workbook, Is.Not.Null);
-      Assert.That(workbookPart.Workbook.Sheets, Is.Not.Null);
+      Assert.That(workbookPart.Workbook!.Sheets, Is.Not.Null);
       Assert.That(expectedSheetsCount, Is.EqualTo(workbookPart.Workbook.Sheets!.Count()));
       Assert.That(expectedRowsCount, Is.EqualTo(rows.Count));
       Assert.That(expectedCellsCount, Is.EqualTo(cells.Count()));


### PR DESCRIPTION
## Context

XLSX files generated by `SimpleExcelExporter` open in Excel and LibreOffice but are rejected by **Apple Numbers**. Numbers strictly enforces the ECMA-376 / ISO/IEC 29500 (OOXML) specification where Excel and LibreOffice are permissive.

This PR makes generated files compliant and validates with Apple Numbers, Microsoft Excel, and LibreOffice Calc.

**Public API is unchanged** — all fixes are internal to `SpreadSheetWriter.cs`. Consumers (Prothesis2 and others) do not need any code changes, only a version bump after this lands.

## Final implementation: streaming direct OOXML generation

The branch history shows two phases. The **final implementation** is the streaming refactor (last 5 commits). Earlier commits document the post-processing approach that was functional but architecturally superseded.

### Streaming architecture (final state)

- `ZipArchive` directly on caller's `_stream` — **no intermediate `MemoryStream`**
- Each entry written exactly once — **no ZIP re-opening / re-compression**
- `OpenXmlWriter` for structured parts (`workbook.xml`, `styles.xml`, `worksheets/sheet*.xml`)
- `XmlWriter` for flat parts (`[Content_Types].xml`, `_rels/.rels`, `xl/_rels/workbook.xml.rels`, `docProps/core.xml`)
- **No regex** — correctness is produced first-write, not patched post-hoc
- **No `partial` class** — single straightforward `SpreadsheetWriter`

### OOXML compliance fixes (from earlier phase, preserved)

| Fix | Description |
|---|---|
| `r` attributes | Rows carry `r="N"`, cells carry `r="A1"` (via `ColumnReferenceHelper.ToLetters`) |
| Dynamic `SheetDimension` | `A1:X6` computed from actual used range |
| `[Content_Types].xml` | `Default Extension="xml"` = `application/xml` + explicit Override for core.xml |
| Text cells | `t="inlineStr"` with `<is><t>…</t></is>` (NOT `t="str"` which is reserved for formula results) |
| Empty cells | Self-closing `<c r="X" t="inlineStr"/>` |
| Namespaces | Default (no `x:` prefix) on `<worksheet>`, `<workbook>`, `<styleSheet>`; `xmlns:r` on `<workbook>` root |
| `docProps/core.xml` | Populated with `dc:creator`, `dcterms:created`, `dcterms:modified` |
| `xl/styles.xml` | Complete with `numFmts`, `cellStyles`, `tableStyles` |
| Relationship IDs | Sequential `rId1`, `rId2`, `rId3` (never GUIDs) |
| Relationship targets | All relative paths (no leading `/`) |

## Dependency bump

Also bumps `DocumentFormat.OpenXml` from `3.2.0` to `3.5.1`.

## Tests

- 28/28 unit tests pass (no test modification needed by the refactor — passing tests validate the streaming approach produces equivalent OOXML)
- Regression suite includes `SpreadSheetWriterTest` (SDK round-trip via `SpreadsheetDocument.Open`), `ColumnReferenceHelperTest` (11 cases), `SpreadSheetWriterOoxmlComplianceTest` (5 structural invariants)

## Validation

- ✅ Apple Numbers (macOS) — validated by a Mac user across multiple iterations
- ✅ Microsoft Excel
- ✅ LibreOffice Calc

## Out of scope (handled separately)

- Bump `<Version>` in `SimpleExcelExporter.csproj` and publish `1.5.0` to NuGet
- Bump the `SimpleExcelExporter` dependency from `1.4.4` → `1.5.0` in consuming projects
- Azure DevOps sync