### PR TITLE
feat: Apple Numbers compatibility, streaming XLSX writer, and release tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+      nunit:
+        patterns:
+          - "NUnit*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Describe what the PR does and why. Link any related issues. -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Breaking change? If yes, describe the migration in the PR description and plan a MAJOR version bump
+- [ ] If this PR ships user-visible changes: `<Version>` in `src/SimpleExcelExporter/SimpleExcelExporter.csproj` bumped accordingly (see [RELEASING.md](../RELEASING.md))
+- [ ] After merge: create and push a tag `v<version>` on `master` to trigger the NuGet publish (the release is not automatic on merge)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --configuration Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,8 +17,10 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+        cache: true
+        cache-dependency-path: '**/packages.lock.json'
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore --locked-mode
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: CI
 
 on:
   push:
@@ -23,9 +23,3 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Pack
-      run: dotnet pack --verbosity normal --configuration release
-    - name: Push
-      env: # environment variable
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push --api-key "$NUGET_API_KEY" --skip-duplicate --source https://api.nuget.org/v3/index.json src/SimpleExcelExporter/bin/release/SimpleExcelExporter.*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+        cache: true
+        cache-dependency-path: '**/packages.lock.json'
 
     - name: Verify tag matches csproj version
       run: |
@@ -34,7 +36,7 @@ jobs:
         fi
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore --locked-mode
 
     - name: Build
       run: dotnet build --no-restore --configuration release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Verify tag matches csproj version
       run: |
         TAG="${GITHUB_REF#refs/tags/v}"
-        CSPROJ_VERSION=$(sed -n 's|.*<Version>\(.*\)</Version>.*|\1|p' src/SimpleExcelExporter/SimpleExcelExporter.csproj)
+        CSPROJ_VERSION=$(sed -n 's|.*<Version>\(.*\)</Version>.*|\1|p' src/SimpleExcelExporter/SimpleExcelExporter.csproj | head -1)
         if [ "$TAG" != "$CSPROJ_VERSION" ]; then
           echo "::error::Tag v$TAG does not match csproj <Version>$CSPROJ_VERSION</Version>"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Verify tag matches csproj version
+      run: |
+        TAG="${GITHUB_REF#refs/tags/v}"
+        CSPROJ_VERSION=$(sed -n 's|.*<Version>\(.*\)</Version>.*|\1|p' src/SimpleExcelExporter/SimpleExcelExporter.csproj)
+        if [ "$TAG" != "$CSPROJ_VERSION" ]; then
+          echo "::error::Tag v$TAG does not match csproj <Version>$CSPROJ_VERSION</Version>"
+          exit 1
+        fi
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration release
+
+    - name: Test
+      run: dotnet test --no-build --configuration release --verbosity normal
+
+    - name: Pack
+      run: dotnet pack --no-build --configuration release
+
+    - name: Push to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push --api-key "$NUGET_API_KEY" --skip-duplicate --source https://api.nuget.org/v3/index.json src/SimpleExcelExporter/bin/release/SimpleExcelExporter.*.nupkg
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,13 @@ jobs:
     - name: Verify tag matches csproj version
       run: |
         TAG="${GITHUB_REF#refs/tags/v}"
-        CSPROJ_VERSION=$(sed -n 's|.*<Version>\(.*\)</Version>.*|\1|p' src/SimpleExcelExporter/SimpleExcelExporter.csproj | head -1)
+        CSPROJ=src/SimpleExcelExporter/SimpleExcelExporter.csproj
+        VERSION_COUNT=$(grep -c '<Version>' "$CSPROJ" || true)
+        if [ "$VERSION_COUNT" -ne 1 ]; then
+          echo "::error::Expected exactly one <Version> element in $CSPROJ, found $VERSION_COUNT"
+          exit 1
+        fi
+        CSPROJ_VERSION=$(sed -n 's|.*<Version>\(.*\)</Version>.*|\1|p' "$CSPROJ")
         if [ "$TAG" != "$CSPROJ_VERSION" ]; then
           echo "::error::Tag v$TAG does not match csproj <Version>$CSPROJ_VERSION</Version>"
           exit 1

--- a/BENCHMARK_RESULTS.md
+++ b/BENCHMARK_RESULTS.md
@@ -1,0 +1,114 @@
+# Benchmark results — PR #9 performance & file-size analysis
+
+Controlled measurement of runtime and output file sizes across 6 versions of the library, using the same ConsoleApp harness with a seeded `Random(42)` so all runs generate byte-identical data across versions (modulo timestamps).
+
+- **Machine**: Linux, tuxedo laptop, no other user applications running.
+- **Protocol**: 3 runs per version, same build, results reported as medians. File sizes are reported in bytes (stable across runs thanks to the fixed seed — variance ≤ 1 byte).
+- **Harness**: [`scripts/benchmark.sh`](scripts/benchmark.sh) — portable, reproducible (commit list and output dir configurable at the top of the script / via env vars).
+- **Persistent XLSX outputs**: `~/SimpleExcelExporter-bench-outputs/<version-label>/` for direct opening in Excel / Numbers / LibreOffice.
+
+## Versions benchmarked
+
+| # | Label | Commit | What changed |
+|---|---|---|---|
+| 1 | `01-master` | `0e3a966` | master — pre-PR reference |
+| 2 | `02-before-shared` | `ac59ba6` | PR #9 compliance + refactor, before any size optim |
+| 3 | `03-after-shared` | `679355f` | + shared strings table |
+| 4 | `04-A-skip-empty` | `b57ebc5` | + skip empty cells (optim A) |
+| 5 | `05-B-omit-s0` | `7070d23` | + omit `s="0"` default style (optim B) |
+| 6 | `06-C-omit-tn` | `d298204` | + omit `t="n"` default type (optim C) |
+
+## Runtime (medians of 3 runs, seconds)
+
+| Version | Total runtime | Δ vs master |
+|---|---:|---:|
+| `01-master` | **93.20 s** | — (baseline) |
+| `02-before-shared` | 126.77 s | +33.57 s (**+36 %**) |
+| `03-after-shared` | 125.56 s | +32.36 s (+35 %) |
+| `04-A-skip-empty` | 128.65 s | +35.45 s (+38 %) |
+| `05-B-omit-s0` | 128.43 s | +35.23 s (+38 %) |
+| `06-C-omit-tn` | 125.91 s | +32.71 s (+35 %) |
+
+**Reading** : the PR adds a ~35 % runtime overhead vs master (price of compliance and streaming refactor). The three size optims (A, B, C) are **perf-neutral** — variation within ±3 s is noise.
+
+## File sizes (`TestWithData3.xlsx`, 1 M rows × 20 cols, annotated path)
+
+| Version | Size | Δ vs master | Δ vs previous step |
+|---|---:|---:|---:|
+| `01-master` | **47.2 MB** | — | — |
+| `02-before-shared` | 109.4 MB | +62.3 MB (**+132 %**) | +62.3 MB |
+| `03-after-shared` | 109.2 MB | +62.1 MB (+132 %) | −0.2 MB (≈ 0) |
+| `04-A-skip-empty` | 97.7 MB | +50.6 MB (+107 %) | **−11.5 MB** (−11 %) |
+| `05-B-omit-s0` | 96.7 MB | +49.5 MB (+105 %) | −1.0 MB (−1 %) |
+| `06-C-omit-tn` | **95.0 MB** | +47.9 MB (+101 %) | **−1.6 MB** (−2 %) |
+
+**Reading** : the compliance bump inflated the file by 132 % (62 MB). The three optims together recovered 14 MB. We remain **+101 %** above master, fundamentally because Apple Numbers requires the `r="A1"` attribute on every cell.
+
+## File sizes (other fixtures)
+
+### `TestWithData4.xlsx` (1 M rows, `WorkbookDfn` path, dense sheet)
+
+| Version | Size | Δ vs master |
+|---|---:|---:|
+| `01-master` | **30.8 MB** | — |
+| `02-before-shared` | 55.6 MB | +24.8 MB (+80 %) |
+| `03-after-shared` | 55.9 MB | +25.1 MB (+81 %) |
+| `04-A-skip-empty` | 55.9 MB | +25.1 MB (+81 %) |
+| `05-B-omit-s0` | 55.5 MB | +24.7 MB (+80 %) |
+| `06-C-omit-tn` | 55.4 MB | +24.6 MB (+80 %) |
+
+**Reading** : the `WorkbookDfn` path has very few empty cells, so optim A doesn't help. Optims B and C each save a modest ~0.4 MB.
+
+### `TestWithData5.xlsx` (`Group` fixture, 16 k persons hierarchy)
+
+| Version | Size | Δ vs master |
+|---|---:|---:|
+| `01-master` | 48.6 KB | — |
+| `02-before-shared` | 128.9 KB | +80.3 KB (+165 %) |
+| `03-after-shared` | 175.3 KB | +126.7 KB (+260 %) |
+| `04-A-skip-empty` | 175.3 KB | +126.7 KB (+260 %) |
+| `05-B-omit-s0` | 166.7 KB | +118.1 KB (+243 %) |
+| `06-C-omit-tn` | 166.7 KB | +118.1 KB (+243 %) |
+
+**Reading** : shared strings *hurt* this fixture (+46 KB) because all ~16 k person names are unique → the table stores them all without deduplication gain, and the added `sharedStrings.xml` + rels/content-types overhead dominates. Optim B recovers a bit. None of the size optims pay off on workloads without repeated strings or empty cells.
+
+### Small fixtures (baseline shapes)
+
+| Fixture | 01-master | 02-before-shared | 03-after-shared | 04-A | 05-B | 06-C |
+|---|---:|---:|---:|---:|---:|---:|
+| `TestWithData1.xlsx` | 4.0 KB | 4.2 KB | 4.5 KB | 4.5 KB | 4.5 KB | 4.5 KB |
+| `TestWithData2.xlsx` | 3.1 KB | 3.4 KB | 3.7 KB | 3.7 KB | 3.7 KB | 3.7 KB |
+| `TestWithDataEmpty.xlsx` | 2.7 KB | 2.8 KB | 3.0 KB | 3.0 KB | 3.0 KB | 3.0 KB |
+
+Negligible movements on small workbooks — the metadata cost dominates over any data.
+
+## Summary of findings
+
+1. **Compliance has a real cost.** The PR makes files 80–132 % larger and runtime 35 % slower on a 1 M-row annotated export. That's the price to pay for Apple Numbers acceptance (mandatory `r="A1"` per cell).
+
+2. **Shared strings are perf-neutral on our data** (runtime and size). They're kept because they're the XLSX convention; the memory-allocation improvement may matter on leaner machines.
+
+3. **Skip empty cells (A)** is the biggest size win on annotated paths with `MultiColumn` padding (−11 %). Zero gain elsewhere.
+
+4. **Omit default attributes (B, C)** each trim 1–2 % more. Modest but free (single-line changes, no behaviour change, accepted by every reader we tested).
+
+5. **Cumulative gain of A + B + C**: −14 MB on the 1 M-row annotated fixture (109 → 95 MB). Enough to drop below Google Sheets' 100 MB upload limit.
+
+6. **Google Sheets has a 10 M cell limit** orthogonal to file size. `TestWithData3.xlsx` (20 M cells) won't open in Google Sheets regardless.
+
+## Validation to-dos
+
+The following open items still need empirical validation — the OOXML spec allows them, but strict readers don't always honour the spec:
+
+- [ ] Open `~/SimpleExcelExporter-bench-outputs/06-C-omit-tn/TestWithData3.xlsx` in **Apple Numbers**. The A/B/C optims (empty cells omitted, `s="0"` omitted, `t="n"` omitted) were reasoned from spec but not re-validated on Numbers after the initial compliance work on commit `fee0e01`.
+- [ ] Spot-check in Excel (Windows + macOS) and LibreOffice Calc.
+- [ ] If any reader refuses, revert the culprit commit (B or C is easy to revert; A is the big-gain one).
+
+## Artifacts
+
+- Benchmark script: [`scripts/benchmark.sh`](scripts/benchmark.sh) — re-run with `./scripts/benchmark.sh` from the repo root.
+- Raw CSV (default path): `/tmp/benchmark-results.csv` (one row per run).
+- Run log (default path): `/tmp/benchmark.log`.
+- XLSX outputs per version (default path): `~/SimpleExcelExporter-bench-outputs/<label>/`.
+
+Override via environment variables: `RUNS`, `OUTPUT_DIR`, `LOG`, `REPORT`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,99 @@
+# Releasing
+
+This document describes how to publish a new version of `SimpleExcelExporter` to NuGet.
+
+## TL;DR
+
+1. Open a PR that bumps `<Version>` in `src/SimpleExcelExporter/SimpleExcelExporter.csproj`.
+2. Merge the PR to `master`.
+3. Create a git tag that matches the version (prefixed with `v`) and push it.
+4. The `Release` workflow publishes to NuGet and creates a GitHub Release.
+
+No package is ever published without an explicit tag. There is no rush — tag only when you are ready.
+
+## Step by step
+
+### 1. Bump the version
+
+Edit `src/SimpleExcelExporter/SimpleExcelExporter.csproj`:
+
+```xml
+<Version>1.5.0</Version>
+```
+
+Follow [Semantic Versioning](https://semver.org):
+
+- **PATCH** (`1.4.4` → `1.4.5`): backwards-compatible bug fix.
+- **MINOR** (`1.4.x` → `1.5.0`): new backwards-compatible capability. A change that produces different output for an existing call (new spreadsheet features, new compatibility) counts as MINOR even if no new public method is added.
+- **MAJOR** (`1.x.x` → `2.0.0`): breaking change of the public API.
+
+Open a PR, get it reviewed, merge to `master`.
+
+### 2. Create and push the tag
+
+Once merged:
+
+```bash
+git checkout master
+git pull
+git tag -a v1.5.0 -m "Release 1.5.0"
+git push origin v1.5.0
+```
+
+The tag format is always `v` followed by the exact version string in the csproj.
+
+### 3. The workflow does the rest
+
+`.github/workflows/release.yml` triggers on any tag matching `v*` and:
+
+1. Verifies that the tag matches `<Version>` in the csproj. If not, the release aborts before anything is published.
+2. Restores, builds, and tests the solution in `Release` configuration.
+3. Packs `SimpleExcelExporter.<version>.nupkg`.
+4. Pushes it to [nuget.org](https://www.nuget.org/packages/SimpleExcelExporter) using the `NUGET_API_KEY` repository secret and `--skip-duplicate` (safe to re-run).
+5. Creates a GitHub Release on the tag with auto-generated notes.
+
+## Pre-releases
+
+For testing a version in a downstream project before committing to a stable release, use a SemVer pre-release suffix:
+
+```xml
+<Version>1.5.0-alpha.1</Version>
+```
+
+```bash
+git tag -a v1.5.0-alpha.1 -m "Pre-release 1.5.0-alpha.1"
+git push origin v1.5.0-alpha.1
+```
+
+Iterate with `-alpha.2`, `-alpha.3`, then `-beta.1`, `-rc.1` as the version stabilizes. Consumers must reference the exact version (or use a wildcard like `1.5.0-alpha.*`) because NuGet hides pre-releases by default.
+
+When the pre-release campaign is over:
+
+```xml
+<Version>1.5.0</Version>
+```
+
+Tag `v1.5.0`. The stable release supersedes the pre-releases (which stay published but can be unlisted from the nuget.org UI if desired).
+
+## Troubleshooting
+
+### The release workflow failed on "Verify tag matches csproj version"
+
+The tag and the csproj `<Version>` disagree. Either:
+
+- Delete the mismatched tag and re-tag with the correct version:
+  ```bash
+  git tag -d v1.5.0
+  git push origin :refs/tags/v1.5.0
+  git tag -a v1.5.0 -m "Release 1.5.0"
+  git push origin v1.5.0
+  ```
+- Or, if the csproj is wrong, open a quick PR to fix it, then re-tag.
+
+### `dotnet nuget push` says the version already exists
+
+`--skip-duplicate` turns this into a success; no action needed. If you genuinely need to change a published package, increment the version — NuGet does not allow overwriting a published package.
+
+### I forgot to tag and merged a release-bumping PR
+
+Nothing was published. Create the tag on `master` any time — the workflow will run at that moment.

--- a/SimpleExcelExporter.sln.DotSettings
+++ b/SimpleExcelExporter.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Calibri/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=officedocument/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preparator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preparators/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Perf & file-size benchmark harness used to produce BENCHMARK_RESULTS.md.
+#
+# What it does:
+#   1. Snapshots the current src/ConsoleApp/ (so every version is benchmarked with the
+#      same seeded data generator).
+#   2. For each version in STATES below: git checkout, overlay the snapshot on ConsoleApp,
+#      build in Release, run the ConsoleApp RUNS times, capture total runtime and the file
+#      sizes of every .xlsx produced.
+#   3. On the last run of each version, copies the produced .xlsx files to
+#      $OUTPUT_DIR/<label>/ so they can be opened in Excel / Numbers / LibreOffice.
+#   4. Returns to the starting branch.
+#
+# Usage:
+#   ./scripts/benchmark.sh
+#
+# Environment variables (all optional):
+#   OUTPUT_DIR   Destination for the generated .xlsx files per version.
+#                Default: $HOME/SimpleExcelExporter-bench-outputs
+#   RUNS         Runs per state (median reported in BENCHMARK_RESULTS.md).
+#                Default: 3
+#   LOG          Run log path. Default: /tmp/benchmark.log
+#   REPORT       CSV output path. Default: /tmp/benchmark-results.csv
+#
+# Expected duration: ~40 min for 6 states × 3 runs on the default fixture
+# (TestWithData3 = 1 M rows × 20 cols).
+#
+# Notes:
+#   - The STATES array references specific commit SHAs. Update it if you want to
+#     benchmark a different slice of history.
+#   - The script restores the starting branch on completion, but force-checkout
+#     (-f) discards any uncommitted changes in tracked files. Commit or stash
+#     before running.
+#   - Requires a seeded Random in ConsoleApp (committed in 487f810) for
+#     reproducible file sizes between runs.
+
+set -e
+
+# Resolve the repo root from this script's location, so callers can invoke it
+# from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OUTPUT_DIR="${OUTPUT_DIR:-$HOME/SimpleExcelExporter-bench-outputs}"
+RUNS="${RUNS:-3}"
+LOG="${LOG:-/tmp/benchmark.log}"
+REPORT="${REPORT:-/tmp/benchmark-results.csv}"
+SNAPSHOT="/tmp/benchmark-consoleapp-snapshot"
+
+# Versions to benchmark: "label sha".
+# Add or remove entries to change the coverage.
+STATES=(
+  "01-master          0e3a966"
+  "02-before-shared   ac59ba6"
+  "03-after-shared    679355f"
+  "04-A-skip-empty    b57ebc5"
+  "05-B-omit-s0       7070d23"
+  "06-C-omit-tn       d298204"
+)
+
+STARTING_BRANCH="$(cd "$REPO" && git rev-parse --abbrev-ref HEAD)"
+cd "$REPO"
+
+echo "state,run,total_s,size_Data1,size_Data2,size_Data3,size_Data4,size_Data5,size_DataEmpty" > "$REPORT"
+: > "$LOG"
+
+# Snapshot the current (seeded) ConsoleApp. This is what gets layered onto every
+# checked-out version, so every run exercises the same data generator — only the
+# library under test (src/SimpleExcelExporter/) varies between states.
+rm -rf "$SNAPSHOT"
+mkdir -p "$SNAPSHOT"
+cp -r "$REPO/src/ConsoleApp/." "$SNAPSHOT/"
+echo "=== $(date +%H:%M:%S) snapshot saved to $SNAPSHOT ===" >> "$LOG"
+
+mkdir -p "$OUTPUT_DIR"
+
+run_state() {
+  local label=$1 sha=$2
+  local version_dir="$OUTPUT_DIR/$label"
+  mkdir -p "$version_dir"
+  {
+    echo "=== $(date +%H:%M:%S) $label ($sha) ==="
+    git checkout -f "$sha" 2>&1
+    cp -r "$SNAPSHOT/." "$REPO/src/ConsoleApp/" 2>&1
+    dotnet restore --nologo --verbosity quiet 2>&1 || true
+  } >> "$LOG" 2>&1
+
+  if ! dotnet build --no-restore --configuration Release --nologo --verbosity quiet >> "$LOG" 2>&1; then
+    echo "=== $(date +%H:%M:%S) BUILD FAILED on $label ($sha) — skipping ===" >> "$LOG"
+    echo "$label,BUILD-FAILED,0,0,0,0,0,0,0" >> "$REPORT"
+    return 0
+  fi
+
+  for i in $(seq 1 "$RUNS"); do
+    rm -rf "$REPO/src/ConsoleApp/bin/release/net8.0/ExampleOutput-"* 2>/dev/null || true
+    echo "  $(date +%H:%M:%S) $label run $i/$RUNS..." >> "$LOG"
+    local out total
+    out=$(cd "$REPO/src/ConsoleApp/bin/release/net8.0" && ./ConsoleApp 2>&1)
+    total=$(echo "$out" | grep "Total execution time" | awk '{print $4}')
+    local dir="$REPO/src/ConsoleApp/bin/release/net8.0"
+    local outputdir
+    outputdir=$(ls -d "$dir"/ExampleOutput-* 2>/dev/null | head -1)
+    local s1 s2 s3 s4 s5 se
+    s1=$(stat -c%s "$outputdir/TestWithData1.xlsx" 2>/dev/null || echo "0")
+    s2=$(stat -c%s "$outputdir/TestWithData2.xlsx" 2>/dev/null || echo "0")
+    s3=$(stat -c%s "$outputdir/TestWithData3.xlsx" 2>/dev/null || echo "0")
+    s4=$(stat -c%s "$outputdir/TestWithData4.xlsx" 2>/dev/null || echo "0")
+    s5=$(stat -c%s "$outputdir/TestWithData5.xlsx" 2>/dev/null || echo "0")
+    se=$(stat -c%s "$outputdir/TestWithDataEmpty.xlsx" 2>/dev/null || echo "0")
+    echo "$label,$i,$total,$s1,$s2,$s3,$s4,$s5,$se" >> "$REPORT"
+    echo "    $(date +%H:%M:%S) total=${total}s data3=${s3}B" >> "$LOG"
+
+    if [ "$i" = "$RUNS" ]; then
+      cp "$outputdir/"*.xlsx "$version_dir/" 2>/dev/null || true
+      echo "    $(date +%H:%M:%S) xlsx copied to $version_dir" >> "$LOG"
+    fi
+  done
+}
+
+for entry in "${STATES[@]}"; do
+  # Split the entry on whitespace into label + sha.
+  # shellcheck disable=SC2086
+  set -- $entry
+  run_state "$1" "$2"
+done
+
+git checkout -f "$STARTING_BRANCH" >> "$LOG" 2>&1
+echo "=== $(date +%H:%M:%S) DONE ===" >> "$LOG"
+echo "Results:  $REPORT"
+echo "Log:      $LOG"
+echo "Outputs:  $OUTPUT_DIR"

--- a/src/ConsoleApp/ConsoleApp.csproj
+++ b/src/ConsoleApp/ConsoleApp.csproj
@@ -9,6 +9,7 @@
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <IsPackable>false</IsPackable>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -87,8 +87,11 @@ namespace ConsoleApp
       using var memoryStream = new MemoryStream();
       using var streamWriter = new StreamWriter(memoryStream);
       var team = new Team();
-      var rnd = new Random();
-      var weakPseudoRandomDate = new WeakPseudoRandomDateTime();
+      // Fixed seeds make the generated data deterministic across runs — essential for
+      // before/after size and timing comparisons during perf work. No production impact:
+      // ConsoleApp is a benchmark harness, not a shipped product.
+      var rnd = new Random(42);
+      var weakPseudoRandomDate = new WeakPseudoRandomDateTime(42);
       Console.WriteLine("Generating the players...");
       var stopwatch = new Stopwatch();
       stopwatch.Start();
@@ -181,8 +184,11 @@ namespace ConsoleApp
       var workbookDfn = new WorkbookDfn();
       var worksheetDfn = new WorksheetDfn("Team");
       workbookDfn.Worksheets.Add(worksheetDfn);
-      var rnd = new Random();
-      var weakPseudoRandomDate = new WeakPseudoRandomDateTime();
+      // Fixed seeds make the generated data deterministic across runs — essential for
+      // before/after size and timing comparisons during perf work. No production impact:
+      // ConsoleApp is a benchmark harness, not a shipped product.
+      var rnd = new Random(42);
+      var weakPseudoRandomDate = new WeakPseudoRandomDateTime(42);
       Console.WriteLine("Generating the players...");
       var stopwatch = new Stopwatch();
       stopwatch.Start();

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -15,6 +15,8 @@ namespace ConsoleApp
   {
     public static void Main()
     {
+      var totalStopwatch = Stopwatch.StartNew();
+
       // First test: try to create empty Excel file
       var n = DateTime.Now;
       var tempDi = new DirectoryInfo($"ExampleOutput-{n.Year - 2000:00}-{n.Month:00}-{n.Day:00}-{n.Hour:00}{n.Minute:00}{n.Second:00}");
@@ -26,6 +28,10 @@ namespace ConsoleApp
       GenerateBigSpreadsheetFromAnnotatedData(tempDi);
       GenerateBigSpreadsheetFromWorkBookDfn(tempDi);
       GenerateSpreadsheetFromGroup(tempDi);
+
+      totalStopwatch.Stop();
+      Console.WriteLine();
+      Console.WriteLine($"Total execution time: {totalStopwatch.Elapsed.TotalSeconds:F2} seconds ({totalStopwatch.Elapsed:hh\\:mm\\:ss})");
     }
 
     private static void GenerateSpreadsheetFromGroup(DirectoryInfo tempDi)

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -36,9 +36,10 @@ namespace ConsoleApp
 
     private static void GenerateSpreadsheetFromGroup(DirectoryInfo tempDi)
     {
-      Console.WriteLine("GenerateBigSpreadsheetFromAnnotatedData");
+      Console.WriteLine("GenerateSpreadsheetFromGroup");
       using var memoryStream = new MemoryStream();
       using var streamWriter = new StreamWriter(memoryStream);
+      Console.WriteLine("Generating the persons...");
       var stopwatch = new Stopwatch();
       stopwatch.Start();
       var group = new Group();

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -15,7 +15,7 @@ namespace ConsoleApp
   {
     public static void Main()
     {
-      // First test : try to create empty Excel file
+      // First test: try to create empty Excel file
       var n = DateTime.Now;
       var tempDi = new DirectoryInfo($"ExampleOutput-{n.Year - 2000:00}-{n.Month:00}-{n.Day:00}-{n.Hour:00}{n.Minute:00}{n.Second:00}");
       tempDi.Create();
@@ -56,10 +56,6 @@ namespace ConsoleApp
       stopwatch.Stop();
       Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
-      // Note: the SpreadsheetWriter constructor does more than allocate — it runs
-      // BuildWorkbook (reflection over annotated objects, only on the annotated
-      // overload), OrderWorkBookDfn, and Validate. For annotated inputs this is
-      // typically the slowest phase.
       Console.WriteLine("Preparing the SpreadsheetWriter...");
       stopwatch.Reset();
       stopwatch.Start();

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -54,21 +54,25 @@ namespace ConsoleApp
       }
 
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
-      Console.WriteLine("Instantiating the SpreadsheetWriter...");
+      // Note: the SpreadsheetWriter constructor does more than allocate — it runs
+      // BuildWorkbook (reflection over annotated objects, only on the annotated
+      // overload), OrderWorkBookDfn, and Validate. For annotated inputs this is
+      // typically the slowest phase.
+      Console.WriteLine("Preparing the SpreadsheetWriter...");
       stopwatch.Reset();
       stopwatch.Start();
       var spreadsheetWriter = new SpreadsheetWriter(streamWriter.BaseStream, group);
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       Console.WriteLine("Writing the Excel file...");
       stopwatch.Reset();
       stopwatch.Start();
       spreadsheetWriter.Write();
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       using var file = new FileStream(Path.Combine(tempDi.FullName, "TestWithData5.xlsx"), FileMode.Create, FileAccess.Write);
       memoryStream.WriteTo(file);
@@ -146,21 +150,21 @@ namespace ConsoleApp
       }
 
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
-      Console.WriteLine("Instantiating the SpreadsheetWriter...");
+      Console.WriteLine("Preparing the SpreadsheetWriter...");
       stopwatch.Reset();
       stopwatch.Start();
       var spreadsheetWriter = new SpreadsheetWriter(streamWriter.BaseStream, team);
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       Console.WriteLine("Writing the Excel file...");
       stopwatch.Reset();
       stopwatch.Start();
       spreadsheetWriter.Write();
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       using var file = new FileStream(Path.Combine(tempDi.FullName, "TestWithData3.xlsx"), FileMode.Create, FileAccess.Write);
       memoryStream.WriteTo(file);
@@ -199,21 +203,21 @@ namespace ConsoleApp
       }
 
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
-      Console.WriteLine("Instantiating the SpreadsheetWriter...");
+      Console.WriteLine("Preparing the SpreadsheetWriter...");
       stopwatch.Reset();
       stopwatch.Start();
       var spreadsheetWriter = new SpreadsheetWriter(streamWriter.BaseStream, workbookDfn);
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       Console.WriteLine("Writing the Excel file...");
       stopwatch.Reset();
       stopwatch.Start();
       spreadsheetWriter.Write();
       stopwatch.Stop();
-      Console.WriteLine($"Done in {stopwatch.Elapsed.Seconds} seconds !");
+      Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:F2} seconds !");
 
       using var file = new FileStream(Path.Combine(tempDi.FullName, "TestWithData4.xlsx"), FileMode.Create, FileAccess.Write);
       memoryStream.WriteTo(file);

--- a/src/ConsoleApp/WeakPseudoRandomDateTime.cs
+++ b/src/ConsoleApp/WeakPseudoRandomDateTime.cs
@@ -8,10 +8,10 @@
     private readonly Random _gen;
     private readonly int _range;
 
-    public WeakPseudoRandomDateTime()
+    public WeakPseudoRandomDateTime(int seed)
     {
       _start = new DateTime(1970, 1, 1);
-      _gen = new Random();
+      _gen = new Random(seed);
       _range = (DateTime.Today - _start).Days;
     }
 

--- a/src/ConsoleApp/packages.lock.json
+++ b/src/ConsoleApp/packages.lock.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "DocumentFormat.OpenXml": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "zxdOf5VVCe/uNklbRhj8dVBzQGj3DoqkUuqOp9cAZVuN8mNYDjof1lvSQA2OQNr8Ptc9d7pbA7Azq/ReaI3FpA==",
+        "dependencies": {
+          "DocumentFormat.OpenXml.Framework": "3.5.1"
+        }
+      },
+      "DocumentFormat.OpenXml.Framework": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "U5txtc3ORno73xQx9Lf2gWzfaSZnZwKHfLkTAslhlew9lxe5XbUiCt0dY1fHeAf8yRqszUAe5i/+xLC9R/Xfsw==",
+        "dependencies": {
+          "System.IO.Packaging": "8.0.1"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.IO.Packaging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "KYkIOAvPexQOLDxPO2g0BVoWInnQhPpkFzRqvNrNrMhVT6kqhVr0zEb6KCHlptLFukxnZrjuMVAnxK7pOGUYrw=="
+      },
+      "simpleexcelexporter": {
+        "type": "Project",
+        "dependencies": {
+          "DocumentFormat.OpenXml": "[3.5.1, )"
+        }
+      }
+    }
+  }
+}

--- a/src/SimpleExcelExporter/ColumnReferenceHelper.cs
+++ b/src/SimpleExcelExporter/ColumnReferenceHelper.cs
@@ -1,0 +1,36 @@
+namespace SimpleExcelExporter
+{
+  using System;
+  using System.Text;
+
+  /// <summary>
+  /// Converts 1-indexed column numbers to their A1 spreadsheet notation.
+  /// </summary>
+  public static class ColumnReferenceHelper
+  {
+    /// <summary>
+    /// Converts a 1-indexed column number to its A1 letter notation.
+    /// </summary>
+    /// <param name="columnIndex">The 1-indexed column number (1 → "A", 27 → "AA").</param>
+    /// <returns>The column letters.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="columnIndex"/> is less than 1.</exception>
+    public static string ToLetters(int columnIndex)
+    {
+      if (columnIndex < 1)
+      {
+        throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, "Column index must be 1 or greater.");
+      }
+
+      var builder = new StringBuilder();
+      var remaining = columnIndex;
+      while (remaining > 0)
+      {
+        var modulo = (remaining - 1) % 26;
+        builder.Insert(0, (char)('A' + modulo));
+        remaining = (remaining - 1) / 26;
+      }
+
+      return builder.ToString();
+    }
+  }
+}

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -18,6 +18,8 @@
     <RepositoryUrl>https://github.com/Prothesis-Dental-Solutions/SimpleExcelExporter</RepositoryUrl>
     <PackageTags>Excel;export;Open-XML-SDK;xlsx;ooxml</PackageTags>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -17,6 +17,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Prothesis-Dental-Solutions/SimpleExcelExporter</RepositoryUrl>
     <PackageTags>Excel;export;Open-XML-SDK;xlsx;ooxml</PackageTags>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>1.4.5-alpha</Version>
+    <Version>1.5.0-alpha.1</Version>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Helps exporting objects to an Excel file (.xlsx).</Description>

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -20,6 +20,9 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -42,6 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>1.4.4</Version>
+    <Version>1.4.5-alpha</Version>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Helps exporting objects to an Excel file (.xlsx).</Description>

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -17,13 +17,16 @@ namespace SimpleExcelExporter
 
   public class SpreadsheetWriter
   {
-    private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
-
-    private const string PackageRelationshipsNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
-
-    private const string RelationshipsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-
-    private const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private static readonly Dictionary<CellValues, string> CellTypeAttributes = new()
+    {
+      [CellValues.Boolean] = "b",
+      [CellValues.Date] = "d",
+      [CellValues.Error] = "e",
+      [CellValues.InlineString] = "inlineStr",
+      [CellValues.Number] = "n",
+      [CellValues.SharedString] = "s",
+      [CellValues.String] = "str",
+    };
 
     private readonly Dictionary<string, Attribute?> _cachedAttributes = [];
 
@@ -143,45 +146,8 @@ namespace SimpleExcelExporter
       return index;
     }
 
-    private static string ToCellTypeAttribute(CellValues value)
-    {
-      if (value == CellValues.Boolean)
-      {
-        return "b";
-      }
-
-      if (value == CellValues.Date)
-      {
-        return "d";
-      }
-
-      if (value == CellValues.Error)
-      {
-        return "e";
-      }
-
-      if (value == CellValues.InlineString)
-      {
-        return "inlineStr";
-      }
-
-      if (value == CellValues.Number)
-      {
-        return "n";
-      }
-
-      if (value == CellValues.SharedString)
-      {
-        return "s";
-      }
-
-      if (value == CellValues.String)
-      {
-        return "str";
-      }
-
-      return value.ToString();
-    }
+    private static string ToCellTypeAttribute(CellValues value) =>
+      CellTypeAttributes.TryGetValue(value, out var attribute) ? attribute : value.ToString();
 
     private static void WriteCoreProperties(ZipArchive archive)
     {
@@ -206,7 +172,7 @@ namespace SimpleExcelExporter
 
     private static void WriteOverride(XmlWriter writer, string partName, string contentType)
     {
-      writer.WriteStartElement("Override", ContentTypesNamespace);
+      writer.WriteStartElement("Override", Ns.ContentTypes);
       writer.WriteAttributeString("PartName", partName);
       writer.WriteAttributeString("ContentType", contentType);
       writer.WriteEndElement();
@@ -224,7 +190,7 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+      writer.WriteStartElement("Relationships", Ns.PackageRelationships);
 
       WriteRelationship(
         writer,
@@ -244,7 +210,7 @@ namespace SimpleExcelExporter
 
     private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
     {
-      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
+      writer.WriteStartElement("Relationship", Ns.PackageRelationships);
       writer.WriteAttributeString("Id", id);
       writer.WriteAttributeString("Type", type);
       writer.WriteAttributeString("Target", target);
@@ -790,14 +756,14 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement("Types", ContentTypesNamespace);
+      writer.WriteStartElement("Types", Ns.ContentTypes);
 
-      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteStartElement("Default", Ns.ContentTypes);
       writer.WriteAttributeString("Extension", "xml");
       writer.WriteAttributeString("ContentType", "application/xml");
       writer.WriteEndElement();
 
-      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteStartElement("Default", Ns.ContentTypes);
       writer.WriteAttributeString("Extension", "rels");
       writer.WriteAttributeString("ContentType", "application/vnd.openxmlformats-package.relationships+xml");
       writer.WriteEndElement();
@@ -827,49 +793,49 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement(string.Empty, "styleSheet", SpreadsheetMlNamespace);
+      writer.WriteStartElement(string.Empty, "styleSheet", Ns.SpreadsheetMl);
 
       // numFmts
-      writer.WriteStartElement("numFmts", SpreadsheetMlNamespace);
+      writer.WriteStartElement("numFmts", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "0");
       writer.WriteEndElement();
 
       // fonts
-      writer.WriteStartElement("fonts", SpreadsheetMlNamespace);
+      writer.WriteStartElement("fonts", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "1");
-      writer.WriteStartElement("font", SpreadsheetMlNamespace);
-      writer.WriteStartElement("sz", SpreadsheetMlNamespace);
+      writer.WriteStartElement("font", Ns.SpreadsheetMl);
+      writer.WriteStartElement("sz", Ns.SpreadsheetMl);
       writer.WriteAttributeString("val", "11");
       writer.WriteEndElement();
-      writer.WriteStartElement("name", SpreadsheetMlNamespace);
+      writer.WriteStartElement("name", Ns.SpreadsheetMl);
       writer.WriteAttributeString("val", "Calibri");
       writer.WriteEndElement();
-      writer.WriteStartElement("family", SpreadsheetMlNamespace);
+      writer.WriteStartElement("family", Ns.SpreadsheetMl);
       writer.WriteAttributeString("val", "2");
       writer.WriteEndElement();
-      writer.WriteStartElement("scheme", SpreadsheetMlNamespace);
+      writer.WriteStartElement("scheme", Ns.SpreadsheetMl);
       writer.WriteAttributeString("val", "minor");
       writer.WriteEndElement();
       writer.WriteEndElement(); // font
       writer.WriteEndElement(); // fonts
 
       // fills
-      writer.WriteStartElement("fills", SpreadsheetMlNamespace);
+      writer.WriteStartElement("fills", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "1");
-      writer.WriteStartElement("fill", SpreadsheetMlNamespace);
-      writer.WriteStartElement("patternFill", SpreadsheetMlNamespace);
+      writer.WriteStartElement("fill", Ns.SpreadsheetMl);
+      writer.WriteStartElement("patternFill", Ns.SpreadsheetMl);
       writer.WriteAttributeString("patternType", "none");
       writer.WriteEndElement();
       writer.WriteEndElement();
       writer.WriteEndElement();
 
       // borders
-      writer.WriteStartElement("borders", SpreadsheetMlNamespace);
+      writer.WriteStartElement("borders", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "1");
-      writer.WriteStartElement("border", SpreadsheetMlNamespace);
+      writer.WriteStartElement("border", Ns.SpreadsheetMl);
       foreach (var tag in new[] { "left", "right", "top", "bottom", "diagonal" })
       {
-        writer.WriteStartElement(tag, SpreadsheetMlNamespace);
+        writer.WriteStartElement(tag, Ns.SpreadsheetMl);
         writer.WriteEndElement();
       }
 
@@ -877,9 +843,9 @@ namespace SimpleExcelExporter
       writer.WriteEndElement(); // borders
 
       // cellStyleXfs
-      writer.WriteStartElement("cellStyleXfs", SpreadsheetMlNamespace);
+      writer.WriteStartElement("cellStyleXfs", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "1");
-      writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+      writer.WriteStartElement("xf", Ns.SpreadsheetMl);
       writer.WriteAttributeString("numFmtId", "0");
       writer.WriteAttributeString("fontId", "0");
       writer.WriteAttributeString("fillId", "0");
@@ -888,11 +854,11 @@ namespace SimpleExcelExporter
       writer.WriteEndElement();
 
       // cellXfs — one xf per style produced by CreateOrGetStylIndex
-      writer.WriteStartElement("cellXfs", SpreadsheetMlNamespace);
+      writer.WriteStartElement("cellXfs", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", _numberFormatIds.Count.ToString(CultureInfo.InvariantCulture));
       foreach (var numberFormatId in _numberFormatIds)
       {
-        writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+        writer.WriteStartElement("xf", Ns.SpreadsheetMl);
         writer.WriteAttributeString("numFmtId", numberFormatId.ToString(CultureInfo.InvariantCulture));
         writer.WriteAttributeString("fontId", "0");
         writer.WriteAttributeString("fillId", "0");
@@ -907,9 +873,9 @@ namespace SimpleExcelExporter
       writer.WriteEndElement(); // cellXfs
 
       // cellStyles
-      writer.WriteStartElement("cellStyles", SpreadsheetMlNamespace);
+      writer.WriteStartElement("cellStyles", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "1");
-      writer.WriteStartElement("cellStyle", SpreadsheetMlNamespace);
+      writer.WriteStartElement("cellStyle", Ns.SpreadsheetMl);
       writer.WriteAttributeString("name", "Normal");
       writer.WriteAttributeString("xfId", "0");
       writer.WriteAttributeString("builtinId", "0");
@@ -917,7 +883,7 @@ namespace SimpleExcelExporter
       writer.WriteEndElement();
 
       // tableStyles
-      writer.WriteStartElement("tableStyles", SpreadsheetMlNamespace);
+      writer.WriteStartElement("tableStyles", Ns.SpreadsheetMl);
       writer.WriteAttributeString("count", "0");
       writer.WriteAttributeString("defaultTableStyle", "TableStyleMedium9");
       writer.WriteAttributeString("defaultPivotStyle", "PivotStyleLight16");
@@ -939,23 +905,23 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement(string.Empty, "workbook", SpreadsheetMlNamespace);
-      writer.WriteAttributeString("xmlns", "r", null, RelationshipsNamespace);
+      writer.WriteStartElement(string.Empty, "workbook", Ns.SpreadsheetMl);
+      writer.WriteAttributeString("xmlns", "r", null, Ns.Relationships);
 
-      writer.WriteStartElement("bookViews", SpreadsheetMlNamespace);
-      writer.WriteStartElement("workbookView", SpreadsheetMlNamespace);
+      writer.WriteStartElement("bookViews", Ns.SpreadsheetMl);
+      writer.WriteStartElement("workbookView", Ns.SpreadsheetMl);
       writer.WriteEndElement();
       writer.WriteEndElement();
 
-      writer.WriteStartElement("sheets", SpreadsheetMlNamespace);
+      writer.WriteStartElement("sheets", Ns.SpreadsheetMl);
       var sheetId = 1U;
       var rId = 2;
       foreach (var ws in _workbookDfn.Worksheets)
       {
-        writer.WriteStartElement("sheet", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheet", Ns.SpreadsheetMl);
         writer.WriteAttributeString("name", ws.Name);
         writer.WriteAttributeString("sheetId", sheetId.ToString(CultureInfo.InvariantCulture));
-        writer.WriteAttributeString("r", "id", RelationshipsNamespace, $"rId{rId}");
+        writer.WriteAttributeString("r", "id", Ns.Relationships, $"rId{rId}");
         writer.WriteEndElement();
         sheetId++;
         rId++;
@@ -979,7 +945,7 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+      writer.WriteStartElement("Relationships", Ns.PackageRelationships);
 
       WriteRelationship(
         writer,
@@ -1023,33 +989,33 @@ namespace SimpleExcelExporter
           : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
 
         writer.WriteStartDocument(standalone: true);
-        writer.WriteStartElement(string.Empty, "worksheet", SpreadsheetMlNamespace);
+        writer.WriteStartElement(string.Empty, "worksheet", Ns.SpreadsheetMl);
 
-        writer.WriteStartElement("dimension", SpreadsheetMlNamespace);
+        writer.WriteStartElement("dimension", Ns.SpreadsheetMl);
         writer.WriteAttributeString("ref", reference);
         writer.WriteEndElement();
 
-        writer.WriteStartElement("sheetViews", SpreadsheetMlNamespace);
-        writer.WriteStartElement("sheetView", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheetViews", Ns.SpreadsheetMl);
+        writer.WriteStartElement("sheetView", Ns.SpreadsheetMl);
         writer.WriteAttributeString("tabSelected", count == 1U ? "1" : "0");
         writer.WriteAttributeString("workbookViewId", "0");
-        writer.WriteStartElement("selection", SpreadsheetMlNamespace);
+        writer.WriteStartElement("selection", Ns.SpreadsheetMl);
         writer.WriteAttributeString("activeCell", "A1");
         writer.WriteAttributeString("sqref", "A1");
         writer.WriteEndElement();
         writer.WriteEndElement(); // sheetView
         writer.WriteEndElement(); // sheetViews
 
-        writer.WriteStartElement("sheetFormatPr", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheetFormatPr", Ns.SpreadsheetMl);
         writer.WriteAttributeString("defaultRowHeight", "15");
         writer.WriteAttributeString("defaultColWidth", "15");
         writer.WriteEndElement();
 
         // sheetData
-        writer.WriteStartElement("sheetData", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheetData", Ns.SpreadsheetMl);
         foreach (var row in sheetData.Elements<Row>())
         {
-          writer.WriteStartElement("row", SpreadsheetMlNamespace);
+          writer.WriteStartElement("row", Ns.SpreadsheetMl);
           if (row.RowIndex != null)
           {
             writer.WriteAttributeString("r", row.RowIndex.Value.ToString(CultureInfo.InvariantCulture));
@@ -1057,7 +1023,7 @@ namespace SimpleExcelExporter
 
           foreach (var cell in row.Elements<Cell>())
           {
-            writer.WriteStartElement("c", SpreadsheetMlNamespace);
+            writer.WriteStartElement("c", Ns.SpreadsheetMl);
             if (cell.CellReference != null)
             {
               writer.WriteAttributeString("r", cell.CellReference.Value);
@@ -1075,15 +1041,15 @@ namespace SimpleExcelExporter
 
             if (cell.CellValue != null)
             {
-              writer.WriteStartElement("v", SpreadsheetMlNamespace);
+              writer.WriteStartElement("v", Ns.SpreadsheetMl);
               writer.WriteString(cell.CellValue.Text);
               writer.WriteEndElement();
             }
 
             if (cell.InlineString != null)
             {
-              writer.WriteStartElement("is", SpreadsheetMlNamespace);
-              writer.WriteStartElement("t", SpreadsheetMlNamespace);
+              writer.WriteStartElement("is", Ns.SpreadsheetMl);
+              writer.WriteStartElement("t", Ns.SpreadsheetMl);
               writer.WriteString(cell.InlineString.Text?.Text ?? string.Empty);
               writer.WriteEndElement();
               writer.WriteEndElement();
@@ -1097,7 +1063,7 @@ namespace SimpleExcelExporter
 
         writer.WriteEndElement(); // sheetData
 
-        writer.WriteStartElement("pageMargins", SpreadsheetMlNamespace);
+        writer.WriteStartElement("pageMargins", Ns.SpreadsheetMl);
         writer.WriteAttributeString("left", "0.7");
         writer.WriteAttributeString("right", "0.7");
         writer.WriteAttributeString("top", "0.75");
@@ -1111,6 +1077,17 @@ namespace SimpleExcelExporter
 
         count++;
       }
+    }
+
+    private static class Ns
+    {
+      public const string ContentTypes = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+      public const string PackageRelationships = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+      public const string Relationships = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+      public const string SpreadsheetMl = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     }
   }
 }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -38,7 +38,13 @@ namespace SimpleExcelExporter
 
     private readonly List<uint> _numberFormatIds = [];
 
+    private readonly List<string> _sharedStrings = [];
+
+    private readonly Dictionary<string, int> _sharedStringsIndex = [];
+
     private readonly WorkbookDfn _workbookDfn;
+
+    private int _sharedStringsTotalCount;
 
     /// <summary>
     /// Initializes a new <see cref="SpreadsheetWriter"/> from an explicit <see cref="WorkbookDfn"/>.
@@ -85,8 +91,8 @@ namespace SimpleExcelExporter
       // cf. https://issuetracker.google.com/issues/210875597
       using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-      // WriteStyles must run AFTER WriteWorksheets so that _numberFormatIds
-      // has been populated by CreateOrGetStylIndex during cell creation.
+      // WriteStyles and WriteSharedStrings must run AFTER WriteWorksheets so that
+      // _numberFormatIds and _sharedStrings have been populated during cell creation.
       WriteContentTypes(archive);
       WritePackageRelationships(archive);
       WriteCoreProperties(archive);
@@ -94,6 +100,7 @@ namespace SimpleExcelExporter
       WriteWorkbook(archive);
       WriteWorksheets(archive);
       WriteStyles(archive);
+      WriteSharedStrings(archive);
     }
 
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
@@ -610,11 +617,18 @@ namespace SimpleExcelExporter
       }
       else if (cellDfn.Value is string stringValue)
       {
-        cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
-        if (!string.IsNullOrEmpty(stringValue))
+        if (string.IsNullOrEmpty(stringValue))
+        {
+          // Empty strings stay as self-closing inlineStr — matches Apple Numbers' preferred shape
+          // and avoids polluting the shared-strings table with empty entries.
+          cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
+        }
+        else
         {
           stringValue = XmlStringHelper.Sanitize(stringValue);
-          cell.InlineString = new InlineString { Text = new Text(stringValue) };
+          var index = GetOrAddSharedString(stringValue);
+          cell.DataType = new EnumValue<CellValues>(CellValues.SharedString);
+          cell.CellValue = new CellValue(index.ToString(CultureInfo.InvariantCulture));
         }
       }
       else if (cellDfn.Value is TimeSpan timeSpanValue)
@@ -789,11 +803,55 @@ namespace SimpleExcelExporter
 
       WriteOverride(writer, "/xl/workbook.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
       WriteOverride(writer, "/xl/styles.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
+      WriteOverride(writer, "/xl/sharedStrings.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml");
       WriteOverride(writer, "/docProps/core.xml", "application/vnd.openxmlformats-package.core-properties+xml");
 
       for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
       {
         WriteOverride(writer, $"/xl/worksheets/sheet{i}.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+      }
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
+    }
+
+    private int GetOrAddSharedString(string value)
+    {
+      _sharedStringsTotalCount++;
+      if (_sharedStringsIndex.TryGetValue(value, out var index))
+      {
+        return index;
+      }
+
+      index = _sharedStrings.Count;
+      _sharedStrings.Add(value);
+      _sharedStringsIndex[value] = index;
+      return index;
+    }
+
+    private void WriteSharedStrings(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/sharedStrings.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement(string.Empty, "sst", Ns.SpreadsheetMl);
+      writer.WriteAttributeString("count", _sharedStringsTotalCount.ToString(CultureInfo.InvariantCulture));
+      writer.WriteAttributeString("uniqueCount", _sharedStrings.Count.ToString(CultureInfo.InvariantCulture));
+
+      foreach (var value in _sharedStrings)
+      {
+        writer.WriteStartElement("si", Ns.SpreadsheetMl);
+        writer.WriteStartElement("t", Ns.SpreadsheetMl);
+        writer.WriteString(value);
+        writer.WriteEndElement();
+        writer.WriteEndElement();
       }
 
       writer.WriteEndElement();
@@ -934,7 +992,7 @@ namespace SimpleExcelExporter
 
       writer.WriteStartElement("sheets", Ns.SpreadsheetMl);
       var sheetId = 1U;
-      var rId = 2;
+      var rId = 3;
       foreach (var ws in _workbookDfn.Worksheets)
       {
         writer.WriteStartElement("sheet", Ns.SpreadsheetMl);
@@ -972,7 +1030,13 @@ namespace SimpleExcelExporter
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
         "styles.xml");
 
-      var rId = 2;
+      WriteRelationship(
+        writer,
+        "rId2",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings",
+        "sharedStrings.xml");
+
+      var rId = 3;
       for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
       {
         WriteRelationship(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -188,23 +188,6 @@ namespace SimpleExcelExporter
       return value.ToString();
     }
 
-    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
-    {
-      writer.WriteStartElement("Override", ContentTypesNamespace);
-      writer.WriteAttributeString("PartName", partName);
-      writer.WriteAttributeString("ContentType", contentType);
-      writer.WriteEndElement();
-    }
-
-    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
-    {
-      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
-      writer.WriteAttributeString("Id", id);
-      writer.WriteAttributeString("Type", type);
-      writer.WriteAttributeString("Target", target);
-      writer.WriteEndElement();
-    }
-
     private static void WriteCoreProperties(ZipArchive archive)
     {
       var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
@@ -224,6 +207,14 @@ namespace SimpleExcelExporter
         $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
         "</cp:coreProperties>");
       writer.Flush();
+    }
+
+    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
+    {
+      writer.WriteStartElement("Override", ContentTypesNamespace);
+      writer.WriteAttributeString("PartName", partName);
+      writer.WriteAttributeString("ContentType", contentType);
+      writer.WriteEndElement();
     }
 
     private static void WritePackageRelationships(ZipArchive archive)
@@ -254,6 +245,15 @@ namespace SimpleExcelExporter
 
       writer.WriteEndElement();
       writer.WriteEndDocument();
+    }
+
+    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
+    {
+      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
+      writer.WriteAttributeString("Id", id);
+      writer.WriteAttributeString("Type", type);
+      writer.WriteAttributeString("Target", target);
+      writer.WriteEndElement();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -40,6 +40,15 @@ namespace SimpleExcelExporter
 
     private readonly WorkbookDfn _workbookDfn;
 
+    /// <summary>
+    /// Initializes a new <see cref="SpreadsheetWriter"/> from an explicit <see cref="WorkbookDfn"/>.
+    /// </summary>
+    /// <param name="stream">The destination stream for the XLSX output. The caller keeps ownership and is responsible for disposal.</param>
+    /// <param name="workbookDfn">The fully built workbook definition.</param>
+    /// <remarks>
+    /// The constructor orders the cells in every row and validates the workbook; call <see cref="Write"/>
+    /// afterwards to produce the actual .xlsx file.
+    /// </remarks>
     public SpreadsheetWriter(Stream stream, WorkbookDfn workbookDfn)
     {
       _stream = stream;
@@ -48,6 +57,16 @@ namespace SimpleExcelExporter
       Validate();
     }
 
+    /// <summary>
+    /// Initializes a new <see cref="SpreadsheetWriter"/> from an annotated object graph.
+    /// </summary>
+    /// <param name="stream">The destination stream for the XLSX output. The caller keeps ownership and is responsible for disposal.</param>
+    /// <param name="team">An object whose properties are decorated with SimpleExcelExporter attributes (<c>SheetName</c>, <c>Header</c>, <c>CellDefinition</c>, …).</param>
+    /// <remarks>
+    /// This constructor runs a reflection walk over <paramref name="team"/> to build the underlying
+    /// <see cref="WorkbookDfn"/>, then orders and validates it. For large inputs this phase usually
+    /// dominates the total runtime — more than the subsequent <see cref="Write"/> call.
+    /// </remarks>
     public SpreadsheetWriter(Stream stream, object team)
     {
       _stream = stream;

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -92,6 +92,9 @@ namespace SimpleExcelExporter
       FixRelationshipTargets(buffer);
 
       buffer.Position = 0;
+      FixWorkbookNamespaceDeclaration(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
 
@@ -285,6 +288,50 @@ namespace SimpleExcelExporter
         using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         writer.Write(content);
       }
+    }
+
+    private static void FixWorkbookNamespaceDeclaration(MemoryStream buffer)
+    {
+      const string RelsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+      const string MainNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+      var relsDeclaration = $" xmlns:r=\"{RelsNamespace}\"";
+
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+      var entry = archive.GetEntry("xl/workbook.xml");
+      if (entry == null)
+      {
+        return;
+      }
+
+      string content;
+      using (var entryStream = entry.Open())
+      using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+      {
+        content = reader.ReadToEnd();
+      }
+
+      // If xmlns:r is already on <workbook>, nothing to do
+      var workbookTagEnd = content.IndexOf('>', content.IndexOf("<workbook", StringComparison.Ordinal));
+      var workbookTag = content.Substring(0, workbookTagEnd + 1);
+      if (workbookTag.Contains("xmlns:r=", StringComparison.Ordinal))
+      {
+        return;
+      }
+
+      // Remove xmlns:r declarations anywhere in the document
+      content = content.Replace(relsDeclaration, string.Empty, StringComparison.Ordinal);
+
+      // Add xmlns:r to the <workbook> element
+      content = content.Replace(
+        $"<workbook xmlns=\"{MainNamespace}\"",
+        $"<workbook xmlns:r=\"{RelsNamespace}\" xmlns=\"{MainNamespace}\"",
+        StringComparison.Ordinal);
+
+      entry.Delete();
+      var newEntry = archive.CreateEntry(entry.FullName);
+      using var writerStream = newEntry.Open();
+      using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+      writer.Write(content);
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -610,7 +610,6 @@ namespace SimpleExcelExporter
 
       if (cellDfn.Value == null)
       {
-        cell.InlineString = new InlineString { Text = new Text(string.Empty) };
         cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is DateTime dateTimeValue)
@@ -651,9 +650,12 @@ namespace SimpleExcelExporter
       }
       else if (cellDfn.Value is string stringValue)
       {
-        stringValue = XmlStringHelper.Sanitize(stringValue);
-        cell.InlineString = new InlineString { Text = new Text(stringValue) };
         cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
+        if (!string.IsNullOrEmpty(stringValue))
+        {
+          stringValue = XmlStringHelper.Sanitize(stringValue);
+          cell.InlineString = new InlineString { Text = new Text(stringValue) };
+        }
       }
       else if (cellDfn.Value is TimeSpan timeSpanValue)
       {

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -1129,7 +1129,9 @@ namespace SimpleExcelExporter
               writer.WriteAttributeString("s", cell.StyleIndex.Value.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (cell.DataType != null)
+            // Omit t="n" — OOXML defaults the cell type to number when the t attribute is absent,
+            // matching what Excel emits natively. Other types (s, b, d, inlineStr, etc.) stay.
+            if (cell.DataType != null && cell.DataType.Value != CellValues.Number)
             {
               writer.WriteAttributeString("t", ToCellTypeAttribute(cell.DataType.Value));
             }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -19,6 +19,14 @@ namespace SimpleExcelExporter
 
   public partial class SpreadsheetWriter
   {
+    private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    private const string PackageRelationshipsNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+    private const string RelationshipsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    private const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
     private readonly Dictionary<string, Attribute?> _cachedAttributes = [];
 
     private readonly Dictionary<string, (CellDfn, bool)> _headers = [];

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -7,6 +7,7 @@ namespace SimpleExcelExporter
   using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
+  using System.Text;
   using System.Text.RegularExpressions;
   using System.Xml;
   using System.Xml.Linq;
@@ -413,6 +414,23 @@ namespace SimpleExcelExporter
       }
 
       return index;
+    }
+
+    private static void WriteOverride(XmlWriter writer, string partName, string contentType)
+    {
+      writer.WriteStartElement("Override", ContentTypesNamespace);
+      writer.WriteAttributeString("PartName", partName);
+      writer.WriteAttributeString("ContentType", contentType);
+      writer.WriteEndElement();
+    }
+
+    private static void WriteRelationship(XmlWriter writer, string id, string type, string target)
+    {
+      writer.WriteStartElement("Relationship", PackageRelationshipsNamespace);
+      writer.WriteAttributeString("Id", id);
+      writer.WriteAttributeString("Type", type);
+      writer.WriteAttributeString("Target", target);
+      writer.WriteEndElement();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(
@@ -1057,6 +1075,129 @@ namespace SimpleExcelExporter
       {
         throw new DefinitionException("WorkBook could not be null or empty.");
       }
+    }
+
+    private void WriteContentTypes(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Types", ContentTypesNamespace);
+
+      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteAttributeString("Extension", "xml");
+      writer.WriteAttributeString("ContentType", "application/xml");
+      writer.WriteEndElement();
+
+      writer.WriteStartElement("Default", ContentTypesNamespace);
+      writer.WriteAttributeString("Extension", "rels");
+      writer.WriteAttributeString("ContentType", "application/vnd.openxmlformats-package.relationships+xml");
+      writer.WriteEndElement();
+
+      WriteOverride(writer, "/xl/workbook.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
+      WriteOverride(writer, "/xl/styles.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
+      WriteOverride(writer, "/docProps/core.xml", "application/vnd.openxmlformats-package.core-properties+xml");
+
+      for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
+      {
+        WriteOverride(writer, $"/xl/worksheets/sheet{i}.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+      }
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
+    }
+
+    private void WriteCoreProperties(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
+
+      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+      writer.WriteRaw(
+        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<cp:coreProperties " +
+        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+        "<dc:creator>SimpleExcelExporter</dc:creator>" +
+        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+        "</cp:coreProperties>");
+      writer.Flush();
+    }
+
+    private void WritePackageRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+        "xl/workbook.xml");
+
+      WriteRelationship(
+        writer,
+        "rId2",
+        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
+        "docProps/core.xml");
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
+    }
+
+    private void WriteWorkbookRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+        "styles.xml");
+
+      var rId = 2;
+      for (var i = 1; i <= _workbookDfn.Worksheets.Count; i++)
+      {
+        WriteRelationship(
+          writer,
+          $"rId{rId}",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+          $"worksheets/sheet{i}.xml");
+        rId++;
+      }
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
     }
   }
 }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -62,49 +62,24 @@ namespace SimpleExcelExporter
 
     public void Write()
     {
-      using var buffer = new MemoryStream();
-
       // Adding core file properties is mandatory to avoid a problem with Google Spreadsheet transforming from XLSX to XLSM.
       // cf. https://stackoverflow.com/questions/70319867/avoid-google-spreadsheet-to-convert-an-xlsx-file-created-by-open-xml-sdk-to-xlsm
       // cf. https://github.com/OfficeDev/Open-XML-SDK/issues/1093
       // cf. https://issuetracker.google.com/issues/210875597
-      using (var document = SpreadsheetDocument.Create(buffer, SpreadsheetDocumentType.Workbook))
-      {
-        var coreFilePropPart = document.AddCoreFilePropertiesPart();
-        using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
-        {
-          var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-          writer.WriteRaw(
-            $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-            "<cp:coreProperties " +
-            "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
-            "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
-            "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
-            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-            "<dc:creator>SimpleExcelExporter</dc:creator>" +
-            $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
-            $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
-            "</cp:coreProperties>");
-          writer.Flush();
-        }
+      using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-        CreatePartsForExcel(document);
-      }
+      // Order matters : BuildStylesheetSkeleton must run BEFORE WriteWorksheets
+      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex) ;
+      // and both must run BEFORE WriteStyles serializes _stylesheet.
+      BuildStylesheetSkeleton();
 
-      buffer.Position = 0;
-      FixContentTypesXml(buffer);
-
-      buffer.Position = 0;
-      FixNamespacePrefixes(buffer);
-
-      buffer.Position = 0;
-      FixRelationshipTargets(buffer);
-
-      buffer.Position = 0;
-      FixWorkbookNamespaceDeclaration(buffer);
-
-      buffer.Position = 0;
-      buffer.CopyTo(_stream);
+      WriteContentTypes(archive);
+      WritePackageRels(archive);
+      WriteCoreProperties(archive);
+      WriteWorkbookRels(archive);
+      WriteWorkbook(archive);
+      WriteWorksheets(archive);
+      WriteStyles(archive);
     }
 
     [GeneratedRegex("Target=\"/([^\"]+)\"")]
@@ -416,6 +391,46 @@ namespace SimpleExcelExporter
       return index;
     }
 
+    private static string ToCellTypeAttribute(CellValues value)
+    {
+      if (value == CellValues.Boolean)
+      {
+        return "b";
+      }
+
+      if (value == CellValues.Date)
+      {
+        return "d";
+      }
+
+      if (value == CellValues.Error)
+      {
+        return "e";
+      }
+
+      if (value == CellValues.InlineString)
+      {
+        return "inlineStr";
+      }
+
+      if (value == CellValues.Number)
+      {
+        return "n";
+      }
+
+      if (value == CellValues.SharedString)
+      {
+        return "s";
+      }
+
+      if (value == CellValues.String)
+      {
+        return "str";
+      }
+
+      return value.ToString();
+    }
+
     private static void WriteOverride(XmlWriter writer, string partName, string contentType)
     {
       writer.WriteStartElement("Override", ContentTypesNamespace);
@@ -431,6 +446,57 @@ namespace SimpleExcelExporter
       writer.WriteAttributeString("Type", type);
       writer.WriteAttributeString("Target", target);
       writer.WriteEndElement();
+    }
+
+    private static void WriteCoreProperties(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
+
+      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+      writer.WriteRaw(
+        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<cp:coreProperties " +
+        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+        "<dc:creator>SimpleExcelExporter</dc:creator>" +
+        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+        "</cp:coreProperties>");
+      writer.Flush();
+    }
+
+    private static void WritePackageRels(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+
+      WriteRelationship(
+        writer,
+        "rId1",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+        "xl/workbook.xml");
+
+      WriteRelationship(
+        writer,
+        "rId2",
+        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
+        "docProps/core.xml");
+
+      writer.WriteEndElement();
+      writer.WriteEndDocument();
     }
 
     private void AddCellsToRowFromObjectPropertyInfos(
@@ -1179,30 +1245,9 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
-    private void WriteCoreProperties(ZipArchive archive)
+    private void WriteStyles(ZipArchive archive)
     {
-      var entry = archive.CreateEntry("docProps/core.xml", CompressionLevel.Optimal);
-      using var stream = entry.Open();
-      using var writer = new XmlTextWriter(stream, Encoding.UTF8);
-
-      var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-      writer.WriteRaw(
-        $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-        "<cp:coreProperties " +
-        "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
-        "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
-        "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
-        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-        "<dc:creator>SimpleExcelExporter</dc:creator>" +
-        $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
-        $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
-        "</cp:coreProperties>");
-      writer.Flush();
-    }
-
-    private void WritePackageRels(ZipArchive archive)
-    {
-      var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
+      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
       using var stream = entry.Open();
       var settings = new XmlWriterSettings
       {
@@ -1212,74 +1257,191 @@ namespace SimpleExcelExporter
       using var writer = XmlWriter.Create(stream, settings);
 
       writer.WriteStartDocument(standalone: true);
-      writer.WriteStartElement("Relationships", PackageRelationshipsNamespace);
+      writer.WriteStartElement(string.Empty, "styleSheet", SpreadsheetMlNamespace);
 
-      WriteRelationship(
-        writer,
-        "rId1",
-        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
-        "xl/workbook.xml");
-
-      WriteRelationship(
-        writer,
-        "rId2",
-        "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
-        "docProps/core.xml");
-
+      // numFmts
+      writer.WriteStartElement("numFmts", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "0");
       writer.WriteEndElement();
+
+      // fonts
+      writer.WriteStartElement("fonts", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("font", SpreadsheetMlNamespace);
+      writer.WriteStartElement("sz", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "11");
+      writer.WriteEndElement();
+      writer.WriteStartElement("name", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "Calibri");
+      writer.WriteEndElement();
+      writer.WriteStartElement("family", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "2");
+      writer.WriteEndElement();
+      writer.WriteStartElement("scheme", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("val", "minor");
+      writer.WriteEndElement();
+      writer.WriteEndElement(); // font
+      writer.WriteEndElement(); // fonts
+
+      // fills
+      writer.WriteStartElement("fills", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("fill", SpreadsheetMlNamespace);
+      writer.WriteStartElement("patternFill", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("patternType", "none");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // borders
+      writer.WriteStartElement("borders", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("border", SpreadsheetMlNamespace);
+      foreach (var tag in new[] { "left", "right", "top", "bottom", "diagonal" })
+      {
+        writer.WriteStartElement(tag, SpreadsheetMlNamespace);
+        writer.WriteEndElement();
+      }
+
+      writer.WriteEndElement(); // border
+      writer.WriteEndElement(); // borders
+
+      // cellStyleXfs
+      writer.WriteStartElement("cellStyleXfs", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("numFmtId", "0");
+      writer.WriteAttributeString("fontId", "0");
+      writer.WriteAttributeString("fillId", "0");
+      writer.WriteAttributeString("borderId", "0");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // cellXfs — produced by CreateOrGetStylIndex, iterate CellFormats children
+      var cellFormats = _stylesheet.Elements<CellFormats>().FirstOrDefault();
+      var xfCount = cellFormats?.Count?.Value ?? 0;
+      writer.WriteStartElement("cellXfs", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", xfCount.ToString(CultureInfo.InvariantCulture));
+      if (cellFormats != null)
+      {
+        foreach (var xf in cellFormats.Elements<CellFormat>())
+        {
+          writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+          if (xf.NumberFormatId != null)
+          {
+            writer.WriteAttributeString("numFmtId", xf.NumberFormatId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FontId != null)
+          {
+            writer.WriteAttributeString("fontId", xf.FontId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FillId != null)
+          {
+            writer.WriteAttributeString("fillId", xf.FillId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.BorderId != null)
+          {
+            writer.WriteAttributeString("borderId", xf.BorderId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.FormatId != null)
+          {
+            writer.WriteAttributeString("xfId", xf.FormatId.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          if (xf.ApplyNumberFormat?.Value == true)
+          {
+            writer.WriteAttributeString("applyNumberFormat", "1");
+          }
+
+          if (xf.ApplyFont?.Value == true)
+          {
+            writer.WriteAttributeString("applyFont", "1");
+          }
+
+          if (xf.ApplyFill?.Value == true)
+          {
+            writer.WriteAttributeString("applyFill", "1");
+          }
+
+          if (xf.ApplyBorder?.Value == true)
+          {
+            writer.WriteAttributeString("applyBorder", "1");
+          }
+
+          if (xf.ApplyAlignment?.Value == true)
+          {
+            writer.WriteAttributeString("applyAlignment", "1");
+          }
+
+          writer.WriteEndElement();
+        }
+      }
+
+      writer.WriteEndElement(); // cellXfs
+
+      // cellStyles
+      writer.WriteStartElement("cellStyles", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "1");
+      writer.WriteStartElement("cellStyle", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("name", "Normal");
+      writer.WriteAttributeString("xfId", "0");
+      writer.WriteAttributeString("builtinId", "0");
+      writer.WriteEndElement();
+      writer.WriteEndElement();
+
+      // tableStyles
+      writer.WriteStartElement("tableStyles", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("count", "0");
+      writer.WriteAttributeString("defaultTableStyle", "TableStyleMedium9");
+      writer.WriteAttributeString("defaultPivotStyle", "PivotStyleLight16");
+      writer.WriteEndElement();
+
+      writer.WriteEndElement(); // styleSheet
       writer.WriteEndDocument();
-    }
-
-    private void WriteStyles(ZipArchive archive)
-    {
-      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
-      using var stream = entry.Open();
-      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
-
-      writer.WriteStartDocument(standalone: true);
-      writer.WriteElement(_stylesheet);
     }
 
     private void WriteWorkbook(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
       using var stream = entry.Open();
-      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+      var settings = new XmlWriterSettings
+      {
+        Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        CloseOutput = false,
+      };
+      using var writer = XmlWriter.Create(stream, settings);
 
-      var workbook = new Workbook();
-      workbook.Append(new BookViews(new WorkbookView()));
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteStartElement(string.Empty, "workbook", SpreadsheetMlNamespace);
+      writer.WriteAttributeString("xmlns", "r", null, RelationshipsNamespace);
 
-      var sheets = new Sheets();
-      _ = workbook.AppendChild(sheets);
+      writer.WriteStartElement("bookViews", SpreadsheetMlNamespace);
+      writer.WriteStartElement("workbookView", SpreadsheetMlNamespace);
+      writer.WriteEndElement();
+      writer.WriteEndElement();
 
+      writer.WriteStartElement("sheets", SpreadsheetMlNamespace);
       var sheetId = 1U;
       var rId = 2;
-      foreach (var worksheet in _workbookDfn.Worksheets)
+      foreach (var ws in _workbookDfn.Worksheets)
       {
-        _ = sheets.AppendChild(new Sheet
-        {
-          Name = worksheet.Name,
-          SheetId = sheetId,
-          Id = $"rId{rId}",
-        });
+        writer.WriteStartElement("sheet", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("name", ws.Name);
+        writer.WriteAttributeString("sheetId", sheetId.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("r", "id", RelationshipsNamespace, $"rId{rId}");
+        writer.WriteEndElement();
         sheetId++;
         rId++;
       }
 
-      writer.WriteStartDocument(standalone: true);
+      writer.WriteEndElement(); // sheets
 
-      var namespaceDeclarations = new List<KeyValuePair<string, string>>
-      {
-        new("r", RelationshipsNamespace),
-      };
-
-      writer.WriteStartElement(workbook, Array.Empty<OpenXmlAttribute>(), namespaceDeclarations);
-      foreach (var child in workbook.ChildElements)
-      {
-        writer.WriteElement(child);
-      }
-
-      writer.WriteEndElement();
+      writer.WriteEndElement(); // workbook
+      writer.WriteEndDocument();
     }
 
     private void WriteWorkbookRels(ZipArchive archive)
@@ -1324,33 +1486,105 @@ namespace SimpleExcelExporter
       {
         var entry = archive.CreateEntry($"xl/worksheets/sheet{count}.xml", CompressionLevel.Optimal);
         using var stream = entry.Open();
-        using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+        var settings = new XmlWriterSettings
+        {
+          Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+          CloseOutput = false,
+        };
+        using var writer = XmlWriter.Create(stream, settings);
 
         var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
 
         var reference = lastRowIndex == 0U || maxColumnCount == 0
           ? "A1"
           : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
-        var sheetDimension = new SheetDimension { Reference = reference };
-
-        var sheetViews = new SheetViews();
-        var sheetView = new SheetView { TabSelected = count == 1U, WorkbookViewId = 0U };
-        var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
-        _ = sheetView.AppendChild(selection);
-        _ = sheetViews.AppendChild(sheetView);
-
-        var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
-        var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
-
-        var worksheetElement = new Worksheet();
-        _ = worksheetElement.AppendChild(sheetDimension);
-        _ = worksheetElement.AppendChild(sheetViews);
-        _ = worksheetElement.AppendChild(sheetFormatProperties);
-        _ = worksheetElement.AppendChild(sheetData);
-        _ = worksheetElement.AppendChild(pageMargins);
 
         writer.WriteStartDocument(standalone: true);
-        writer.WriteElement(worksheetElement);
+        writer.WriteStartElement(string.Empty, "worksheet", SpreadsheetMlNamespace);
+
+        writer.WriteStartElement("dimension", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("ref", reference);
+        writer.WriteEndElement();
+
+        writer.WriteStartElement("sheetViews", SpreadsheetMlNamespace);
+        writer.WriteStartElement("sheetView", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("tabSelected", count == 1U ? "1" : "0");
+        writer.WriteAttributeString("workbookViewId", "0");
+        writer.WriteStartElement("selection", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("activeCell", "A1");
+        writer.WriteAttributeString("sqref", "A1");
+        writer.WriteEndElement();
+        writer.WriteEndElement(); // sheetView
+        writer.WriteEndElement(); // sheetViews
+
+        writer.WriteStartElement("sheetFormatPr", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("defaultRowHeight", "15");
+        writer.WriteAttributeString("defaultColWidth", "15");
+        writer.WriteEndElement();
+
+        // sheetData
+        writer.WriteStartElement("sheetData", SpreadsheetMlNamespace);
+        foreach (var row in sheetData.Elements<Row>())
+        {
+          writer.WriteStartElement("row", SpreadsheetMlNamespace);
+          if (row.RowIndex != null)
+          {
+            writer.WriteAttributeString("r", row.RowIndex.Value.ToString(CultureInfo.InvariantCulture));
+          }
+
+          foreach (var cell in row.Elements<Cell>())
+          {
+            writer.WriteStartElement("c", SpreadsheetMlNamespace);
+            if (cell.CellReference != null)
+            {
+              writer.WriteAttributeString("r", cell.CellReference.Value);
+            }
+
+            if (cell.StyleIndex != null)
+            {
+              writer.WriteAttributeString("s", cell.StyleIndex.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (cell.DataType != null)
+            {
+              writer.WriteAttributeString("t", ToCellTypeAttribute(cell.DataType.Value));
+            }
+
+            if (cell.CellValue != null)
+            {
+              writer.WriteStartElement("v", SpreadsheetMlNamespace);
+              writer.WriteString(cell.CellValue.Text);
+              writer.WriteEndElement();
+            }
+
+            if (cell.InlineString != null)
+            {
+              writer.WriteStartElement("is", SpreadsheetMlNamespace);
+              writer.WriteStartElement("t", SpreadsheetMlNamespace);
+              writer.WriteString(cell.InlineString.Text?.Text ?? string.Empty);
+              writer.WriteEndElement();
+              writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement(); // c
+          }
+
+          writer.WriteEndElement(); // row
+        }
+
+        writer.WriteEndElement(); // sheetData
+
+        writer.WriteStartElement("pageMargins", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("left", "0.7");
+        writer.WriteAttributeString("right", "0.7");
+        writer.WriteAttributeString("top", "0.75");
+        writer.WriteAttributeString("bottom", "0.75");
+        writer.WriteAttributeString("header", "0.3");
+        writer.WriteAttributeString("footer", "0.3");
+        writer.WriteEndElement();
+
+        writer.WriteEndElement(); // worksheet
+        writer.WriteEndDocument();
 
         count++;
       }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -65,13 +65,13 @@ namespace SimpleExcelExporter
       // cf. https://issuetracker.google.com/issues/210875597
       using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-      // Order matters : BuildStylesheetSkeleton must run BEFORE WriteWorksheets
-      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex) ;
+      // Order matters: BuildStylesheetSkeleton must run BEFORE WriteWorksheets
+      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex);
       // and both must run BEFORE WriteStyles serializes _stylesheet.
       BuildStylesheetSkeleton();
 
       WriteContentTypes(archive);
-      WritePackageRels(archive);
+      WritePackageRelationships(archive);
       WriteCoreProperties(archive);
       WriteWorkbookRels(archive);
       WriteWorkbook(archive);
@@ -226,7 +226,7 @@ namespace SimpleExcelExporter
       writer.Flush();
     }
 
-    private static void WritePackageRels(ZipArchive archive)
+    private static void WritePackageRelationships(ZipArchive archive)
     {
       var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Optimal);
       using var stream = entry.Open();
@@ -268,7 +268,7 @@ namespace SimpleExcelExporter
 
       while (objectQueue.Count > 0)
       {
-        (var currentPlayer, var currentPlayerTypePropertyInfos, var currentIteration, var currentParentIndex) = objectQueue.Dequeue();
+        var (currentPlayer, currentPlayerTypePropertyInfos, currentIteration, currentParentIndex) = objectQueue.Dequeue();
 
         foreach (var playerTypePropertyInfo in currentPlayerTypePropertyInfos)
         {
@@ -295,7 +295,7 @@ namespace SimpleExcelExporter
 
               // Add empty cells if needed
               var numberOfEmptyCellToAdd = maxNumberOfElement - childIteration + 1;
-              if (childPlayerType != null && childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
+              if (childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
               {
                 for (var i = 0; i < numberOfEmptyCellToAdd; i++)
                 {
@@ -345,7 +345,7 @@ namespace SimpleExcelExporter
 
       while (objectQueue.Count > 0)
       {
-        (var currentPlayer, var currentPlayerType, var currentPlayerTypePropertyInfos, var currentIteration, var currentParentIndex) = objectQueue.Dequeue();
+        var (currentPlayer, currentPlayerType, currentPlayerTypePropertyInfos, currentIteration, currentParentIndex) = objectQueue.Dequeue();
 
         foreach (var playerTypePropertyInfo in currentPlayerTypePropertyInfos)
         {
@@ -371,7 +371,7 @@ namespace SimpleExcelExporter
 
               // Add empty cells if needed
               var numberOfEmptyCellToAdd = maxNumberOfElement - childIteration + 1;
-              if (childPlayerType != null && childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
+              if (childPlayerTypePropertyInfos != null && numberOfEmptyCellToAdd > 0)
               {
                 for (var i = 0; i < numberOfEmptyCellToAdd; i++)
                 {
@@ -413,7 +413,7 @@ namespace SimpleExcelExporter
             else
             {
               // If the currentPlayer was null when the existing headerCell was added in _headers, then we should update the text.
-              (var headerCellDfn, var textCorrectlySetFlag) = value;
+              var (headerCellDfn, textCorrectlySetFlag) = value;
               if (!textCorrectlySetFlag && currentPlayer != null)
               {
                 _ = _headers.Remove(key);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -481,12 +481,13 @@ namespace SimpleExcelExporter
       }
     }
 
-    private Cell CreateCell(CellDfn cellDfn)
+    private Cell CreateCell(CellDfn cellDfn, uint rowIndex, int columnIndex)
     {
       var stylIndex = CreateOrGetStylIndex(cellDfn);
 
       var cell = new Cell
       {
+        CellReference = $"{ColumnReferenceHelper.ToLetters(columnIndex)}{rowIndex}",
         StyleIndex = stylIndex,
       };
 
@@ -551,12 +552,14 @@ namespace SimpleExcelExporter
       return cell;
     }
 
-    private Row CreateHeaderRowForExcel(IEnumerable<CellDfn> columnHeadings)
+    private Row CreateHeaderRowForExcel(IEnumerable<CellDfn> columnHeadings, uint rowIndex)
     {
-      var row = new Row();
+      var row = new Row { RowIndex = rowIndex };
+      var columnIndex = 1;
       foreach (var cellDfn in columnHeadings)
       {
-        _ = row.AppendChild(CreateCell(cellDfn));
+        _ = row.AppendChild(CreateCell(cellDfn, rowIndex, columnIndex));
+        columnIndex++;
       }
 
       return row;
@@ -636,13 +639,14 @@ namespace SimpleExcelExporter
       }
     }
 
-    private Row GenerateRowForChildPartDetail(RowDfn rowDfn)
+    private Row GenerateRowForChildPartDetail(RowDfn rowDfn, uint rowIndex)
     {
-      var row = new Row();
-
+      var row = new Row { RowIndex = rowIndex };
+      var columnIndex = 1;
       foreach (var cellDfn in rowDfn.Cells)
       {
-        _ = row.AppendChild(CreateCell(cellDfn));
+        _ = row.AppendChild(CreateCell(cellDfn, rowIndex, columnIndex));
+        columnIndex++;
       }
 
       return row;
@@ -651,15 +655,18 @@ namespace SimpleExcelExporter
     private SheetData GenerateSheetDataForDetails(WorksheetDfn worksheet)
     {
       var sheetData1 = new SheetData();
+      var currentRowIndex = 1U;
       if (worksheet.ColumnHeadings.Cells.Count > 0)
       {
-        _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells));
+        _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells, currentRowIndex));
+        currentRowIndex++;
       }
 
       foreach (var row in worksheet.Rows)
       {
-        var partsRows = GenerateRowForChildPartDetail(row);
+        var partsRows = GenerateRowForChildPartDetail(row, currentRowIndex);
         _ = sheetData1.AppendChild(partsRows);
+        currentRowIndex++;
       }
 
       return sheetData1;

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -10,7 +10,6 @@ namespace SimpleExcelExporter
   using System.Text;
   using System.Xml;
   using DocumentFormat.OpenXml;
-  using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
   using SimpleExcelExporter.Annotations;
   using SimpleExcelExporter.Definitions;

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -603,6 +603,71 @@ namespace SimpleExcelExporter
       }
     }
 
+    private void BuildStylesheetSkeleton()
+    {
+      // Number formats (empty — using built-in formats only)
+      var numberingFormats = new NumberingFormats { Count = 0U };
+
+      var fonts = new Fonts { Count = 1U };
+
+      // Font 1
+      var font = new Font
+      {
+        FontSize = new FontSize { Val = 11D },
+        FontName = new FontName { Val = "Calibri" },
+        FontFamilyNumbering = new FontFamilyNumbering { Val = 2 },
+        FontScheme = new FontScheme { Val = FontSchemeValues.Minor },
+      };
+
+      _ = fonts.AppendChild(font);
+
+      // Default Fill
+      var fills = new Fills { Count = 1U };
+      var fill = new Fill { PatternFill = new PatternFill { PatternType = PatternValues.None } };
+      _ = fills.AppendChild(fill);
+
+      // Default Border
+      var borders = new Borders { Count = 1U };
+      var border = new Border
+      {
+        LeftBorder = new LeftBorder(),
+        RightBorder = new RightBorder(),
+        TopBorder = new TopBorder(),
+        BottomBorder = new BottomBorder(),
+        DiagonalBorder = new DiagonalBorder(),
+      };
+      _ = borders.AppendChild(border);
+
+      // CellStyleFormats
+      var cellStyleFormats = new CellStyleFormats { Count = 1U };
+      var cellFormat = new CellFormat { NumberFormatId = 0U, FontId = 0U, FillId = 0U, BorderId = 0U };
+      _ = cellStyleFormats.AppendChild(cellFormat);
+
+      // CellFormats — empty, populated by CreateOrGetStylIndex during worksheet processing
+      var cellFormats = new CellFormats { Count = 0U };
+
+      // CellStyles — Excel requires the "Normal" built-in style
+      var cellStyles = new CellStyles { Count = 1U };
+      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
+
+      // TableStyles — empty but required by strict parsers
+      var tableStyles = new TableStyles
+      {
+        Count = 0U,
+        DefaultTableStyle = "TableStyleMedium9",
+        DefaultPivotStyle = "PivotStyleLight16",
+      };
+
+      _ = _stylesheet.AppendChild(numberingFormats);
+      _ = _stylesheet.AppendChild(fonts);
+      _ = _stylesheet.AppendChild(fills);
+      _ = _stylesheet.AppendChild(borders);
+      _ = _stylesheet.AppendChild(cellStyleFormats);
+      _ = _stylesheet.AppendChild(cellFormats);
+      _ = _stylesheet.AppendChild(cellStyles);
+      _ = _stylesheet.AppendChild(tableStyles);
+    }
+
     private string? BuildText(PropertyInfo playerTypePropertyInfo, Type currentPlayerType, object? currentPlayer)
     {
       var headerAttribute = GetAttributeFrom<HeaderAttribute>(playerTypePropertyInfo);
@@ -1165,6 +1230,58 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
+    private void WriteStyles(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+      writer.WriteStartDocument(standalone: true);
+      writer.WriteElement(_stylesheet);
+    }
+
+    private void WriteWorkbook(ZipArchive archive)
+    {
+      var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
+      using var stream = entry.Open();
+      using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+      var workbook = new Workbook();
+      workbook.Append(new BookViews(new WorkbookView()));
+
+      var sheets = new Sheets();
+      _ = workbook.AppendChild(sheets);
+
+      var sheetId = 1U;
+      var rId = 2;
+      foreach (var worksheet in _workbookDfn.Worksheets)
+      {
+        _ = sheets.AppendChild(new Sheet
+        {
+          Name = worksheet.Name,
+          SheetId = sheetId,
+          Id = $"rId{rId}",
+        });
+        sheetId++;
+        rId++;
+      }
+
+      writer.WriteStartDocument(standalone: true);
+
+      var namespaceDeclarations = new List<KeyValuePair<string, string>>
+      {
+        new("r", RelationshipsNamespace),
+      };
+
+      writer.WriteStartElement(workbook, Array.Empty<OpenXmlAttribute>(), namespaceDeclarations);
+      foreach (var child in workbook.ChildElements)
+      {
+        writer.WriteElement(child);
+      }
+
+      writer.WriteEndElement();
+    }
+
     private void WriteWorkbookRels(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
@@ -1198,6 +1315,45 @@ namespace SimpleExcelExporter
 
       writer.WriteEndElement();
       writer.WriteEndDocument();
+    }
+
+    private void WriteWorksheets(ZipArchive archive)
+    {
+      var count = 1U;
+      foreach (var worksheet in _workbookDfn.Worksheets)
+      {
+        var entry = archive.CreateEntry($"xl/worksheets/sheet{count}.xml", CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        using var writer = OpenXmlWriter.Create(stream, Encoding.UTF8);
+
+        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
+
+        var reference = lastRowIndex == 0U || maxColumnCount == 0
+          ? "A1"
+          : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
+        var sheetDimension = new SheetDimension { Reference = reference };
+
+        var sheetViews = new SheetViews();
+        var sheetView = new SheetView { TabSelected = count == 1U, WorkbookViewId = 0U };
+        var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
+        _ = sheetView.AppendChild(selection);
+        _ = sheetViews.AppendChild(sheetView);
+
+        var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
+        var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
+
+        var worksheetElement = new Worksheet();
+        _ = worksheetElement.AppendChild(sheetDimension);
+        _ = worksheetElement.AppendChild(sheetViews);
+        _ = worksheetElement.AppendChild(sheetFormatProperties);
+        _ = worksheetElement.AppendChild(sheetData);
+        _ = worksheetElement.AppendChild(pageMargins);
+
+        writer.WriteStartDocument(standalone: true);
+        writer.WriteElement(worksheetElement);
+
+        count++;
+      }
     }
   }
 }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -63,7 +63,18 @@ namespace SimpleExcelExporter
         var coreFilePropPart = document.AddCoreFilePropertiesPart();
         using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
         {
-          writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
+          var nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+          writer.WriteRaw(
+            $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+            "<cp:coreProperties " +
+            "xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" " +
+            "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" " +
+            "xmlns:dcterms=\"http://purl.org/dc/terms/\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+            "<dc:creator>SimpleExcelExporter</dc:creator>" +
+            $"<dcterms:created xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:created>" +
+            $"<dcterms:modified xsi:type=\"dcterms:W3CDTF\">{nowIso}</dcterms:modified>" +
+            "</cp:coreProperties>");
           writer.Flush();
         }
 

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -73,7 +73,7 @@ namespace SimpleExcelExporter
       WriteContentTypes(archive);
       WritePackageRelationships(archive);
       WriteCoreProperties(archive);
-      WriteWorkbookRels(archive);
+      WriteWorkbookRelationships(archive);
       WriteWorkbook(archive);
       WriteWorksheets(archive);
       WriteStyles(archive);
@@ -1108,7 +1108,7 @@ namespace SimpleExcelExporter
       writer.WriteEndDocument();
     }
 
-    private void WriteWorkbookRels(ZipArchive archive)
+    private void WriteWorkbookRelationships(ZipArchive archive)
     {
       var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Optimal);
       using var stream = entry.Open();

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -813,6 +813,9 @@ namespace SimpleExcelExporter
 
     private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)
     {
+      // Number formats (empty — using built-in formats only)
+      var numberingFormats = new NumberingFormats { Count = 0U };
+
       var fonts = new Fonts { Count = 1U };
 
       // Font 1
@@ -851,11 +854,26 @@ namespace SimpleExcelExporter
       // CellFormats
       var cellFormats = new CellFormats { Count = 0U };
 
+      // CellStyles — Excel requires the "Normal" built-in style
+      var cellStyles = new CellStyles { Count = 1U };
+      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
+
+      // TableStyles — empty but required by strict parsers
+      var tableStyles = new TableStyles
+      {
+        Count = 0U,
+        DefaultTableStyle = "TableStyleMedium9",
+        DefaultPivotStyle = "PivotStyleLight16",
+      };
+
+      _ = _stylesheet.AppendChild(numberingFormats);
       _ = _stylesheet.AppendChild(fonts);
       _ = _stylesheet.AppendChild(fills);
       _ = _stylesheet.AppendChild(borders);
       _ = _stylesheet.AppendChild(cellStyleFormats);
       _ = _stylesheet.AppendChild(cellFormats);
+      _ = _stylesheet.AppendChild(cellStyles);
+      _ = _stylesheet.AppendChild(tableStyles);
 
       workbookStylesPart.Stylesheet = _stylesheet;
     }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -753,14 +753,15 @@ namespace SimpleExcelExporter
       var sheets = new Sheets();
       _ = workbook.AppendChild(sheets);
 
-      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId3");
+      // Styles first, then worksheets — rId2 reserved for styles, rId3+ for sheets
+      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId2");
       GenerateWorkbookStylesPartContent(workbookStylesPart1);
 
       // Thank you https://stackoverflow.com/questions/9120544/openxml-multiple-sheets
       var count = 1U;
       foreach (var worksheet in _workbookDfn.Worksheets)
       {
-        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>($"rId{count + 2}");  // rId3, rId4, ...
         var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
         _ = sheets.AppendChild(sheet);
         var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -101,6 +101,12 @@ namespace SimpleExcelExporter
     [GeneratedRegex("Target=\"/([^\"]+)\"")]
     private static partial Regex AbsoluteTargetRegex();
 
+    [GeneratedRegex("Id=\"R[0-9a-fA-F]{16}\"")]
+    private static partial Regex GuidIdRegex();
+
+    [GeneratedRegex("Id=\"rId(\\d+)\"")]
+    private static partial Regex ExistingRelIdRegex();
+
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
       var headerCellDfn = new CellDfn(text, index: index);
@@ -280,6 +286,24 @@ namespace SimpleExcelExporter
           }
 
           return $"Target=\"{absTarget}\"";
+        });
+
+        // Normalize SDK-generated GUID-style IDs (Id="R<16 hex>") to sequential rIdN
+        var maxExistingId = 0;
+        foreach (Match existing in ExistingRelIdRegex().Matches(content))
+        {
+          var num = int.Parse(existing.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+          if (num > maxExistingId)
+          {
+            maxExistingId = num;
+          }
+        }
+
+        var nextId = maxExistingId;
+        content = GuidIdRegex().Replace(content, _ =>
+        {
+          nextId++;
+          return $"Id=\"rId{nextId}\"";
         });
 
         entry.Delete();

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -7,6 +7,7 @@ namespace SimpleExcelExporter
   using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
+  using System.Text.RegularExpressions;
   using System.Xml;
   using System.Xml.Linq;
   using DocumentFormat.OpenXml;
@@ -16,7 +17,7 @@ namespace SimpleExcelExporter
   using SimpleExcelExporter.Definitions;
   using SimpleExcelExporter.Resources;
 
-  public class SpreadsheetWriter
+  public partial class SpreadsheetWriter
   {
     private readonly Dictionary<string, Attribute?> _cachedAttributes = [];
 
@@ -88,8 +89,14 @@ namespace SimpleExcelExporter
       FixNamespacePrefixes(buffer);
 
       buffer.Position = 0;
+      FixRelationshipTargets(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
+
+    [GeneratedRegex("Target=\"/([^\"]+)\"")]
+    private static partial Regex AbsoluteTargetRegex();
 
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
@@ -229,6 +236,48 @@ namespace SimpleExcelExporter
           .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
           .Replace("<x:", "<", StringComparison.Ordinal)
           .Replace("</x:", "</", StringComparison.Ordinal);
+
+        entry.Delete();
+        var newEntry = archive.CreateEntry(entry.FullName);
+        using var writerStream = newEntry.Open();
+        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+      }
+    }
+
+    private static void FixRelationshipTargets(MemoryStream buffer)
+    {
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+
+      var relsEntries = archive.Entries
+        .Where(e => e.FullName.EndsWith(".rels", StringComparison.Ordinal))
+        .ToList();
+
+      foreach (var entry in relsEntries)
+      {
+        string content;
+        using (var entryStream = entry.Open())
+        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+        {
+          content = reader.ReadToEnd();
+        }
+
+        // Compute base directory: for "_rels/.rels" base is ""; for "xl/_rels/workbook.xml.rels" base is "xl/"
+        var relsIndex = entry.FullName.LastIndexOf("_rels/", StringComparison.Ordinal);
+        var baseDir = relsIndex == 0 ? string.Empty : entry.FullName.Substring(0, relsIndex);
+
+        // Transform absolute targets to relative
+        // Strategy: replace Target="/x/y/z" with the part relative to baseDir
+        content = AbsoluteTargetRegex().Replace(content, match =>
+        {
+          var absTarget = match.Groups[1].Value;
+          if (baseDir.Length > 0 && absTarget.StartsWith(baseDir, StringComparison.Ordinal))
+          {
+            return $"Target=\"{absTarget.Substring(baseDir.Length)}\"";
+          }
+
+          return $"Target=\"{absTarget}\"";
+        });
 
         entry.Delete();
         var newEntry = archive.CreateEntry(entry.FullName);

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -4,9 +4,11 @@ namespace SimpleExcelExporter
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
+  using System.IO.Compression;
   using System.Linq;
   using System.Reflection;
   using System.Xml;
+  using System.Xml.Linq;
   using DocumentFormat.OpenXml;
   using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
@@ -50,20 +52,29 @@ namespace SimpleExcelExporter
 
     public void Write()
     {
-      using var document = SpreadsheetDocument.Create(_stream, SpreadsheetDocumentType.Workbook);
+      using var buffer = new MemoryStream();
 
       // Adding core file properties is mandatory to avoid a problem with Google Spreadsheet transforming from XLSX to XLSM.
       // cf. https://stackoverflow.com/questions/70319867/avoid-google-spreadsheet-to-convert-an-xlsx-file-created-by-open-xml-sdk-to-xlsm
       // cf. https://github.com/OfficeDev/Open-XML-SDK/issues/1093
       // cf. https://issuetracker.google.com/issues/210875597
-      var coreFilePropPart = document.AddCoreFilePropertiesPart();
-      using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
+      using (var document = SpreadsheetDocument.Create(buffer, SpreadsheetDocumentType.Workbook))
       {
-        writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
-        writer.Flush();
+        var coreFilePropPart = document.AddCoreFilePropertiesPart();
+        using (var writer = new XmlTextWriter(coreFilePropPart.GetStream(FileMode.Create), System.Text.Encoding.UTF8))
+        {
+          writer.WriteRaw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\"></cp:coreProperties>");
+          writer.Flush();
+        }
+
+        CreatePartsForExcel(document);
       }
 
-      CreatePartsForExcel(document);
+      buffer.Position = 0;
+      FixContentTypesXml(buffer);
+
+      buffer.Position = 0;
+      buffer.CopyTo(_stream);
     }
 
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
@@ -116,6 +127,60 @@ namespace SimpleExcelExporter
       }
 
       rowDfn.Cells.Add(cellDfn);
+    }
+
+    private static void FixContentTypesXml(MemoryStream buffer)
+    {
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+      var entry = archive.GetEntry("[Content_Types].xml");
+      if (entry == null)
+      {
+        return;
+      }
+
+      XDocument doc;
+      using (var entryStream = entry.Open())
+      {
+        doc = XDocument.Load(entryStream);
+      }
+
+      var ns = XNamespace.Get("http://schemas.openxmlformats.org/package/2006/content-types");
+      var root = doc.Root!;
+
+      var xmlDefault = root.Elements(ns + "Default")
+        .FirstOrDefault(d => (string?)d.Attribute("Extension") == "xml");
+
+      if (xmlDefault != null && (string?)xmlDefault.Attribute("ContentType") != "application/xml")
+      {
+        var displacedContentType = (string?)xmlDefault.Attribute("ContentType");
+        var displacedPartName = displacedContentType switch
+        {
+          "application/vnd.openxmlformats-package.core-properties+xml" => "/docProps/core.xml",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" => "/xl/workbook.xml",
+          _ => null,
+        };
+
+        if (displacedPartName != null)
+        {
+          var alreadyHasOverride = root.Elements(ns + "Override")
+            .Any(o => (string?)o.Attribute("PartName") == displacedPartName);
+
+          if (!alreadyHasOverride)
+          {
+            root.Add(new XElement(
+              ns + "Override",
+              new XAttribute("PartName", displacedPartName),
+              new XAttribute("ContentType", displacedContentType!)));
+          }
+        }
+
+        xmlDefault.SetAttributeValue("ContentType", "application/xml");
+      }
+
+      entry.Delete();
+      var newEntry = archive.CreateEntry("[Content_Types].xml");
+      using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+      doc.Save(entryWriter);
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -1122,7 +1122,9 @@ namespace SimpleExcelExporter
               writer.WriteAttributeString("r", cell.CellReference.Value);
             }
 
-            if (cell.StyleIndex != null)
+            // Omit s="0" — OOXML defaults the style index to 0 when the attribute is absent,
+            // matching what Excel emits natively.
+            if (cell.StyleIndex != null && cell.StyleIndex.Value != 0U)
             {
               writer.WriteAttributeString("s", cell.StyleIndex.Value.ToString(CultureInfo.InvariantCulture));
             }

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -566,8 +566,8 @@ namespace SimpleExcelExporter
 
       if (cellDfn.Value == null)
       {
-        cell.CellValue = new CellValue(string.Empty);
-        cell.DataType = new EnumValue<CellValues>(CellValues.String);
+        cell.InlineString = new InlineString { Text = new Text(string.Empty) };
+        cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is DateTime dateTimeValue)
       {
@@ -608,8 +608,8 @@ namespace SimpleExcelExporter
       else if (cellDfn.Value is string stringValue)
       {
         stringValue = XmlStringHelper.Sanitize(stringValue);
-        cell.CellValue = new CellValue(stringValue);
-        cell.DataType = new EnumValue<CellValues>(CellValues.String);
+        cell.InlineString = new InlineString { Text = new Text(stringValue) };
+        cell.DataType = new EnumValue<CellValues>(CellValues.InlineString);
       }
       else if (cellDfn.Value is TimeSpan timeSpanValue)
       {

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -1106,6 +1106,16 @@ namespace SimpleExcelExporter
 
           foreach (var cell in row.Elements<Cell>())
           {
+            // Omit cells that have no content. OOXML treats missing cells as empty by position
+            // (cell references on the surviving cells let the reader infer gaps). Matches Excel's
+            // native behaviour and slashes file size on sparse sheets such as MultiColumn padding.
+            // Trade-off: a skipped cell also loses its style hint, acceptable for read-only
+            // exports.
+            if (cell.CellValue == null && cell.InlineString == null)
+            {
+              continue;
+            }
+
             writer.WriteStartElement("c", Ns.SpreadsheetMl);
             if (cell.CellReference != null)
             {

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -74,6 +74,9 @@ namespace SimpleExcelExporter
       FixContentTypesXml(buffer);
 
       buffer.Position = 0;
+      FixNamespacePrefixes(buffer);
+
+      buffer.Position = 0;
       buffer.CopyTo(_stream);
     }
 
@@ -181,6 +184,47 @@ namespace SimpleExcelExporter
       var newEntry = archive.CreateEntry("[Content_Types].xml");
       using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
       doc.Save(entryWriter);
+    }
+
+    private static void FixNamespacePrefixes(MemoryStream buffer)
+    {
+      const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+      var prefixedDeclaration = $"xmlns:x=\"{SpreadsheetMlNamespace}\"";
+      var defaultDeclaration = $"xmlns=\"{SpreadsheetMlNamespace}\"";
+
+      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
+
+      var entriesToFix = archive.Entries
+        .Where(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal)
+          && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
+          && !e.FullName.Contains("_rels/", StringComparison.Ordinal))
+        .ToList();
+
+      foreach (var entry in entriesToFix)
+      {
+        string content;
+        using (var entryStream = entry.Open())
+        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
+        {
+          content = reader.ReadToEnd();
+        }
+
+        if (!content.Contains(prefixedDeclaration, StringComparison.Ordinal))
+        {
+          continue;
+        }
+
+        content = content
+          .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
+          .Replace("<x:", "<", StringComparison.Ordinal)
+          .Replace("</x:", "</", StringComparison.Ordinal);
+
+        entry.Delete();
+        var newEntry = archive.CreateEntry(entry.FullName);
+        using var writerStream = newEntry.Open();
+        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+      }
     }
 
     private static void GenerateWorksheetPartContent(

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -33,14 +33,13 @@ namespace SimpleExcelExporter
 
     private readonly Stream _stream;
 
-    private readonly Stylesheet _stylesheet;
+    private readonly List<uint> _numberFormatIds = [];
 
     private readonly WorkbookDfn _workbookDfn;
 
     public SpreadsheetWriter(Stream stream, WorkbookDfn workbookDfn)
     {
       _stream = stream;
-      _stylesheet = new Stylesheet();
       _workbookDfn = workbookDfn;
       OrderWorkBookDfn();
       Validate();
@@ -49,7 +48,6 @@ namespace SimpleExcelExporter
     public SpreadsheetWriter(Stream stream, object team)
     {
       _stream = stream;
-      _stylesheet = new Stylesheet();
       _workbookDfn = BuildWorkbook(team);
       OrderWorkBookDfn();
       Validate();
@@ -65,11 +63,8 @@ namespace SimpleExcelExporter
       // cf. https://issuetracker.google.com/issues/210875597
       using var archive = new ZipArchive(_stream, ZipArchiveMode.Create, leaveOpen: true);
 
-      // Order matters: BuildStylesheetSkeleton must run BEFORE WriteWorksheets
-      // (which populates _stylesheet.CellFormats via CreateOrGetStylIndex);
-      // and both must run BEFORE WriteStyles serializes _stylesheet.
-      BuildStylesheetSkeleton();
-
+      // WriteStyles must run AFTER WriteWorksheets so that _numberFormatIds
+      // has been populated by CreateOrGetStylIndex during cell creation.
       WriteContentTypes(archive);
       WritePackageRelationships(archive);
       WriteCoreProperties(archive);
@@ -426,71 +421,6 @@ namespace SimpleExcelExporter
       }
     }
 
-    private void BuildStylesheetSkeleton()
-    {
-      // Number formats (empty — using built-in formats only)
-      var numberingFormats = new NumberingFormats { Count = 0U };
-
-      var fonts = new Fonts { Count = 1U };
-
-      // Font 1
-      var font = new Font
-      {
-        FontSize = new FontSize { Val = 11D },
-        FontName = new FontName { Val = "Calibri" },
-        FontFamilyNumbering = new FontFamilyNumbering { Val = 2 },
-        FontScheme = new FontScheme { Val = FontSchemeValues.Minor },
-      };
-
-      _ = fonts.AppendChild(font);
-
-      // Default Fill
-      var fills = new Fills { Count = 1U };
-      var fill = new Fill { PatternFill = new PatternFill { PatternType = PatternValues.None } };
-      _ = fills.AppendChild(fill);
-
-      // Default Border
-      var borders = new Borders { Count = 1U };
-      var border = new Border
-      {
-        LeftBorder = new LeftBorder(),
-        RightBorder = new RightBorder(),
-        TopBorder = new TopBorder(),
-        BottomBorder = new BottomBorder(),
-        DiagonalBorder = new DiagonalBorder(),
-      };
-      _ = borders.AppendChild(border);
-
-      // CellStyleFormats
-      var cellStyleFormats = new CellStyleFormats { Count = 1U };
-      var cellFormat = new CellFormat { NumberFormatId = 0U, FontId = 0U, FillId = 0U, BorderId = 0U };
-      _ = cellStyleFormats.AppendChild(cellFormat);
-
-      // CellFormats — empty, populated by CreateOrGetStylIndex during worksheet processing
-      var cellFormats = new CellFormats { Count = 0U };
-
-      // CellStyles — Excel requires the "Normal" built-in style
-      var cellStyles = new CellStyles { Count = 1U };
-      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
-
-      // TableStyles — empty but required by strict parsers
-      var tableStyles = new TableStyles
-      {
-        Count = 0U,
-        DefaultTableStyle = "TableStyleMedium9",
-        DefaultPivotStyle = "PivotStyleLight16",
-      };
-
-      _ = _stylesheet.AppendChild(numberingFormats);
-      _ = _stylesheet.AppendChild(fonts);
-      _ = _stylesheet.AppendChild(fills);
-      _ = _stylesheet.AppendChild(borders);
-      _ = _stylesheet.AppendChild(cellStyleFormats);
-      _ = _stylesheet.AppendChild(cellFormats);
-      _ = _stylesheet.AppendChild(cellStyles);
-      _ = _stylesheet.AppendChild(tableStyles);
-    }
-
     private string? BuildText(PropertyInfo playerTypePropertyInfo, Type currentPlayerType, object? currentPlayer)
     {
       var headerAttribute = GetAttributeFrom<HeaderAttribute>(playerTypePropertyInfo);
@@ -737,42 +667,18 @@ namespace SimpleExcelExporter
         return stylIndex;
       }
 
-      var cellFormat = new CellFormat
+      // https://stackoverflow.com/questions/11781210/c-sharp-open-xml-2-0-numberformatid-range
+      var numberFormatId = cellDfn.CellDataType switch
       {
-        ApplyBorder = true,
-        ApplyFont = true,
-        ApplyNumberFormat = BooleanValue.FromBoolean(true),
-        BorderId = 0U,
-        FillId = 0U,
-        FormatId = 0U,
-        FontId = 0U,
+        CellDataType.Date => 14U, // d/m/yyyy
+        CellDataType.String => 49U, // @
+        CellDataType.Percentage => 10U,
+        CellDataType.Time => 20U, // H:mm
+        _ => 0U,
       };
 
-      // https://stackoverflow.com/questions/11781210/c-sharp-open-xml-2-0-numberformatid-range
-      if (cellDfn.CellDataType == CellDataType.Date)
-      {
-        cellFormat.NumberFormatId = 14U; // d/m/yyyy
-      }
-      else if (cellDfn.CellDataType == CellDataType.String)
-      {
-        cellFormat.NumberFormatId = 49U; // @
-      }
-      else if (cellDfn.CellDataType == CellDataType.Percentage)
-      {
-        cellFormat.NumberFormatId = 10U;
-      }
-      else if (cellDfn.CellDataType == CellDataType.Time)
-      {
-        cellFormat.NumberFormatId = 20U; // H:mm
-      }
-      else
-      {
-        cellFormat.NumberFormatId = 0U;
-      }
-
-      var index = _stylesheet.CellFormats!.Count!.Value;
-      _stylesheet.CellFormats!.Count!.Value++;
-      _ = _stylesheet.CellFormats.AppendChild(cellFormat);
+      var index = (uint)_numberFormatIds.Count;
+      _numberFormatIds.Add(numberFormatId);
       Table.Add(styleHashCode, index);
 
       return index;
@@ -981,68 +887,21 @@ namespace SimpleExcelExporter
       writer.WriteEndElement();
       writer.WriteEndElement();
 
-      // cellXfs — produced by CreateOrGetStylIndex, iterate CellFormats children
-      var cellFormats = _stylesheet.Elements<CellFormats>().FirstOrDefault();
-      var xfCount = cellFormats?.Count?.Value ?? 0;
+      // cellXfs — one xf per style produced by CreateOrGetStylIndex
       writer.WriteStartElement("cellXfs", SpreadsheetMlNamespace);
-      writer.WriteAttributeString("count", xfCount.ToString(CultureInfo.InvariantCulture));
-      if (cellFormats != null)
+      writer.WriteAttributeString("count", _numberFormatIds.Count.ToString(CultureInfo.InvariantCulture));
+      foreach (var numberFormatId in _numberFormatIds)
       {
-        foreach (var xf in cellFormats.Elements<CellFormat>())
-        {
-          writer.WriteStartElement("xf", SpreadsheetMlNamespace);
-          if (xf.NumberFormatId != null)
-          {
-            writer.WriteAttributeString("numFmtId", xf.NumberFormatId.Value.ToString(CultureInfo.InvariantCulture));
-          }
-
-          if (xf.FontId != null)
-          {
-            writer.WriteAttributeString("fontId", xf.FontId.Value.ToString(CultureInfo.InvariantCulture));
-          }
-
-          if (xf.FillId != null)
-          {
-            writer.WriteAttributeString("fillId", xf.FillId.Value.ToString(CultureInfo.InvariantCulture));
-          }
-
-          if (xf.BorderId != null)
-          {
-            writer.WriteAttributeString("borderId", xf.BorderId.Value.ToString(CultureInfo.InvariantCulture));
-          }
-
-          if (xf.FormatId != null)
-          {
-            writer.WriteAttributeString("xfId", xf.FormatId.Value.ToString(CultureInfo.InvariantCulture));
-          }
-
-          if (xf.ApplyNumberFormat?.Value == true)
-          {
-            writer.WriteAttributeString("applyNumberFormat", "1");
-          }
-
-          if (xf.ApplyFont?.Value == true)
-          {
-            writer.WriteAttributeString("applyFont", "1");
-          }
-
-          if (xf.ApplyFill?.Value == true)
-          {
-            writer.WriteAttributeString("applyFill", "1");
-          }
-
-          if (xf.ApplyBorder?.Value == true)
-          {
-            writer.WriteAttributeString("applyBorder", "1");
-          }
-
-          if (xf.ApplyAlignment?.Value == true)
-          {
-            writer.WriteAttributeString("applyAlignment", "1");
-          }
-
-          writer.WriteEndElement();
-        }
+        writer.WriteStartElement("xf", SpreadsheetMlNamespace);
+        writer.WriteAttributeString("numFmtId", numberFormatId.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("fontId", "0");
+        writer.WriteAttributeString("fillId", "0");
+        writer.WriteAttributeString("borderId", "0");
+        writer.WriteAttributeString("xfId", "0");
+        writer.WriteAttributeString("applyNumberFormat", "1");
+        writer.WriteAttributeString("applyFont", "1");
+        writer.WriteAttributeString("applyBorder", "1");
+        writer.WriteEndElement();
       }
 
       writer.WriteEndElement(); // cellXfs

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -8,9 +8,7 @@ namespace SimpleExcelExporter
   using System.Linq;
   using System.Reflection;
   using System.Text;
-  using System.Text.RegularExpressions;
   using System.Xml;
-  using System.Xml.Linq;
   using DocumentFormat.OpenXml;
   using DocumentFormat.OpenXml.Packaging;
   using DocumentFormat.OpenXml.Spreadsheet;
@@ -18,7 +16,7 @@ namespace SimpleExcelExporter
   using SimpleExcelExporter.Definitions;
   using SimpleExcelExporter.Resources;
 
-  public partial class SpreadsheetWriter
+  public class SpreadsheetWriter
   {
     private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
 
@@ -82,15 +80,6 @@ namespace SimpleExcelExporter
       WriteStyles(archive);
     }
 
-    [GeneratedRegex("Target=\"/([^\"]+)\"")]
-    private static partial Regex AbsoluteTargetRegex();
-
-    [GeneratedRegex("Id=\"R[0-9a-fA-F]{16}\"")]
-    private static partial Regex GuidIdRegex();
-
-    [GeneratedRegex("Id=\"rId(\\d+)\"")]
-    private static partial Regex ExistingRelIdRegex();
-
     private static CellDfn AddHeaderCellToWorkSheet(WorksheetDfn worksheetDfn, string text, List<int> index)
     {
       var headerCellDfn = new CellDfn(text, index: index);
@@ -141,237 +130,6 @@ namespace SimpleExcelExporter
       }
 
       rowDfn.Cells.Add(cellDfn);
-    }
-
-    private static void FixContentTypesXml(MemoryStream buffer)
-    {
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-      var entry = archive.GetEntry("[Content_Types].xml");
-      if (entry == null)
-      {
-        return;
-      }
-
-      XDocument doc;
-      using (var entryStream = entry.Open())
-      {
-        doc = XDocument.Load(entryStream);
-      }
-
-      var ns = XNamespace.Get("http://schemas.openxmlformats.org/package/2006/content-types");
-      var root = doc.Root!;
-
-      var xmlDefault = root.Elements(ns + "Default")
-        .FirstOrDefault(d => (string?)d.Attribute("Extension") == "xml");
-
-      if (xmlDefault != null && (string?)xmlDefault.Attribute("ContentType") != "application/xml")
-      {
-        var displacedContentType = (string?)xmlDefault.Attribute("ContentType");
-        var displacedPartName = displacedContentType switch
-        {
-          "application/vnd.openxmlformats-package.core-properties+xml" => "/docProps/core.xml",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" => "/xl/workbook.xml",
-          _ => null,
-        };
-
-        if (displacedPartName != null)
-        {
-          var alreadyHasOverride = root.Elements(ns + "Override")
-            .Any(o => (string?)o.Attribute("PartName") == displacedPartName);
-
-          if (!alreadyHasOverride)
-          {
-            root.Add(new XElement(
-              ns + "Override",
-              new XAttribute("PartName", displacedPartName),
-              new XAttribute("ContentType", displacedContentType!)));
-          }
-        }
-
-        xmlDefault.SetAttributeValue("ContentType", "application/xml");
-      }
-
-      entry.Delete();
-      var newEntry = archive.CreateEntry("[Content_Types].xml");
-      using var entryWriter = new StreamWriter(newEntry.Open(), new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-      doc.Save(entryWriter);
-    }
-
-    private static void FixNamespacePrefixes(MemoryStream buffer)
-    {
-      const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-      var prefixedDeclaration = $"xmlns:x=\"{SpreadsheetMlNamespace}\"";
-      var defaultDeclaration = $"xmlns=\"{SpreadsheetMlNamespace}\"";
-
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-
-      var entriesToFix = archive.Entries
-        .Where(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal)
-          && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
-          && !e.FullName.Contains("_rels/", StringComparison.Ordinal))
-        .ToList();
-
-      foreach (var entry in entriesToFix)
-      {
-        string content;
-        using (var entryStream = entry.Open())
-        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-        {
-          content = reader.ReadToEnd();
-        }
-
-        if (!content.Contains(prefixedDeclaration, StringComparison.Ordinal))
-        {
-          continue;
-        }
-
-        content = content
-          .Replace(prefixedDeclaration, defaultDeclaration, StringComparison.Ordinal)
-          .Replace("<x:", "<", StringComparison.Ordinal)
-          .Replace("</x:", "</", StringComparison.Ordinal);
-
-        entry.Delete();
-        var newEntry = archive.CreateEntry(entry.FullName);
-        using var writerStream = newEntry.Open();
-        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        writer.Write(content);
-      }
-    }
-
-    private static void FixRelationshipTargets(MemoryStream buffer)
-    {
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-
-      var relsEntries = archive.Entries
-        .Where(e => e.FullName.EndsWith(".rels", StringComparison.Ordinal))
-        .ToList();
-
-      foreach (var entry in relsEntries)
-      {
-        string content;
-        using (var entryStream = entry.Open())
-        using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-        {
-          content = reader.ReadToEnd();
-        }
-
-        // Compute base directory: for "_rels/.rels" base is ""; for "xl/_rels/workbook.xml.rels" base is "xl/"
-        var relsIndex = entry.FullName.LastIndexOf("_rels/", StringComparison.Ordinal);
-        var baseDir = relsIndex == 0 ? string.Empty : entry.FullName.Substring(0, relsIndex);
-
-        // Transform absolute targets to relative
-        // Strategy: replace Target="/x/y/z" with the part relative to baseDir
-        content = AbsoluteTargetRegex().Replace(content, match =>
-        {
-          var absTarget = match.Groups[1].Value;
-          if (baseDir.Length > 0 && absTarget.StartsWith(baseDir, StringComparison.Ordinal))
-          {
-            return $"Target=\"{absTarget.Substring(baseDir.Length)}\"";
-          }
-
-          return $"Target=\"{absTarget}\"";
-        });
-
-        // Normalize SDK-generated GUID-style IDs (Id="R<16 hex>") to sequential rIdN
-        var maxExistingId = 0;
-        foreach (Match existing in ExistingRelIdRegex().Matches(content))
-        {
-          var num = int.Parse(existing.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
-          if (num > maxExistingId)
-          {
-            maxExistingId = num;
-          }
-        }
-
-        var nextId = maxExistingId;
-        content = GuidIdRegex().Replace(content, _ =>
-        {
-          nextId++;
-          return $"Id=\"rId{nextId}\"";
-        });
-
-        entry.Delete();
-        var newEntry = archive.CreateEntry(entry.FullName);
-        using var writerStream = newEntry.Open();
-        using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        writer.Write(content);
-      }
-    }
-
-    private static void FixWorkbookNamespaceDeclaration(MemoryStream buffer)
-    {
-      const string RelsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-      const string MainNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-      var relsDeclaration = $" xmlns:r=\"{RelsNamespace}\"";
-
-      using var archive = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true);
-      var entry = archive.GetEntry("xl/workbook.xml");
-      if (entry == null)
-      {
-        return;
-      }
-
-      string content;
-      using (var entryStream = entry.Open())
-      using (var reader = new StreamReader(entryStream, System.Text.Encoding.UTF8))
-      {
-        content = reader.ReadToEnd();
-      }
-
-      // If xmlns:r is already on <workbook>, nothing to do
-      var workbookTagEnd = content.IndexOf('>', content.IndexOf("<workbook", StringComparison.Ordinal));
-      var workbookTag = content.Substring(0, workbookTagEnd + 1);
-      if (workbookTag.Contains("xmlns:r=", StringComparison.Ordinal))
-      {
-        return;
-      }
-
-      // Remove xmlns:r declarations anywhere in the document
-      content = content.Replace(relsDeclaration, string.Empty, StringComparison.Ordinal);
-
-      // Add xmlns:r to the <workbook> element
-      content = content.Replace(
-        $"<workbook xmlns=\"{MainNamespace}\"",
-        $"<workbook xmlns:r=\"{RelsNamespace}\" xmlns=\"{MainNamespace}\"",
-        StringComparison.Ordinal);
-
-      entry.Delete();
-      var newEntry = archive.CreateEntry(entry.FullName);
-      using var writerStream = newEntry.Open();
-      using var writer = new StreamWriter(writerStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-      writer.Write(content);
-    }
-
-    private static void GenerateWorksheetPartContent(
-      WorksheetPart worksheetPart,
-      SheetData sheetData,
-      bool tabSelectedFlag,
-      int maxColumnCount,
-      uint lastRowIndex)
-    {
-      var worksheet = new Worksheet();
-      var reference = lastRowIndex == 0U || maxColumnCount == 0
-        ? "A1"
-        : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
-      var sheetDimension = new SheetDimension { Reference = reference };
-
-      var sheetViews = new SheetViews();
-
-      var sheetView = new SheetView { TabSelected = tabSelectedFlag, WorkbookViewId = 0U };
-      var selection = new Selection { ActiveCell = "A1", SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" } };
-
-      _ = sheetView.AppendChild(selection);
-
-      _ = sheetViews.AppendChild(sheetView);
-      var sheetFormatProperties = new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 15D };
-
-      var pageMargins = new PageMargins { Left = 0.7D, Right = 0.7D, Top = 0.75D, Bottom = 0.75D, Header = 0.3D, Footer = 0.3D };
-      _ = worksheet.AppendChild(sheetDimension);
-      _ = worksheet.AppendChild(sheetViews);
-      _ = worksheet.AppendChild(sheetFormatProperties);
-      _ = worksheet.AppendChild(sheetData);
-      _ = worksheet.AppendChild(pageMargins);
-      worksheetPart.Worksheet = worksheet;
     }
 
     private static List<int> ManageIndex(int iteration, List<int>? parentIndex, IndexAttribute? indexAttribute)
@@ -1021,32 +779,6 @@ namespace SimpleExcelExporter
       return index;
     }
 
-    private void CreatePartsForExcel(SpreadsheetDocument document)
-    {
-      var workbookPart = document.AddWorkbookPart();
-      var workbook = new Workbook();
-      workbook.Append(new BookViews(new WorkbookView()));
-      workbookPart.Workbook = workbook;
-      var sheets = new Sheets();
-      _ = workbook.AppendChild(sheets);
-
-      // Styles first, then worksheets — rId2 reserved for styles, rId3+ for sheets
-      var workbookStylesPart1 = workbookPart.AddNewPart<WorkbookStylesPart>("rId2");
-      GenerateWorkbookStylesPartContent(workbookStylesPart1);
-
-      // Thank you https://stackoverflow.com/questions/9120544/openxml-multiple-sheets
-      var count = 1U;
-      foreach (var worksheet in _workbookDfn.Worksheets)
-      {
-        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>($"rId{count + 2}");  // rId3, rId4, ...
-        var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
-        _ = sheets.AppendChild(sheet);
-        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
-        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U, maxColumnCount, lastRowIndex);
-        count++;
-      }
-    }
-
     private Row GenerateRowForChildPartDetail(RowDfn rowDfn, uint rowIndex)
     {
       var row = new Row { RowIndex = rowIndex };
@@ -1087,73 +819,6 @@ namespace SimpleExcelExporter
 
       var lastRowIndex = currentRowIndex - 1U;
       return (sheetData1, maxColumnCount, lastRowIndex);
-    }
-
-    private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)
-    {
-      // Number formats (empty — using built-in formats only)
-      var numberingFormats = new NumberingFormats { Count = 0U };
-
-      var fonts = new Fonts { Count = 1U };
-
-      // Font 1
-      var font = new Font
-      {
-        FontSize = new FontSize { Val = 11D },
-        FontName = new FontName { Val = "Calibri" },
-        FontFamilyNumbering = new FontFamilyNumbering { Val = 2 },
-        FontScheme = new FontScheme { Val = FontSchemeValues.Minor },
-      };
-
-      _ = fonts.AppendChild(font);
-
-      // Default Fill
-      var fills = new Fills { Count = 1U };
-      var fill = new Fill { PatternFill = new PatternFill { PatternType = PatternValues.None } };
-      _ = fills.AppendChild(fill);
-
-      // Default Border
-      var borders = new Borders { Count = 1U };
-      var border = new Border
-      {
-        LeftBorder = new LeftBorder(),
-        RightBorder = new RightBorder(),
-        TopBorder = new TopBorder(),
-        BottomBorder = new BottomBorder(),
-        DiagonalBorder = new DiagonalBorder(),
-      };
-      _ = borders.AppendChild(border);
-
-      // CellStyleFormats
-      var cellStyleFormats = new CellStyleFormats { Count = 1U };
-      var cellFormat = new CellFormat { NumberFormatId = 0U, FontId = 0U, FillId = 0U, BorderId = 0U };
-      _ = cellStyleFormats.AppendChild(cellFormat);
-
-      // CellFormats
-      var cellFormats = new CellFormats { Count = 0U };
-
-      // CellStyles — Excel requires the "Normal" built-in style
-      var cellStyles = new CellStyles { Count = 1U };
-      _ = cellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
-
-      // TableStyles — empty but required by strict parsers
-      var tableStyles = new TableStyles
-      {
-        Count = 0U,
-        DefaultTableStyle = "TableStyleMedium9",
-        DefaultPivotStyle = "PivotStyleLight16",
-      };
-
-      _ = _stylesheet.AppendChild(numberingFormats);
-      _ = _stylesheet.AppendChild(fonts);
-      _ = _stylesheet.AppendChild(fills);
-      _ = _stylesheet.AppendChild(borders);
-      _ = _stylesheet.AppendChild(cellStyleFormats);
-      _ = _stylesheet.AppendChild(cellFormats);
-      _ = _stylesheet.AppendChild(cellStyles);
-      _ = _stylesheet.AppendChild(tableStyles);
-
-      workbookStylesPart.Stylesheet = _stylesheet;
     }
 
     private T? GetAttributeFrom<T>(PropertyInfo propertyInfo)

--- a/src/SimpleExcelExporter/SpreadSheetWriter.cs
+++ b/src/SimpleExcelExporter/SpreadSheetWriter.cs
@@ -118,10 +118,18 @@ namespace SimpleExcelExporter
       rowDfn.Cells.Add(cellDfn);
     }
 
-    private static void GenerateWorksheetPartContent(WorksheetPart worksheetPart, SheetData sheetData, bool tabSelectedFlag)
+    private static void GenerateWorksheetPartContent(
+      WorksheetPart worksheetPart,
+      SheetData sheetData,
+      bool tabSelectedFlag,
+      int maxColumnCount,
+      uint lastRowIndex)
     {
       var worksheet = new Worksheet();
-      var sheetDimension = new SheetDimension { Reference = "A1" };
+      var reference = lastRowIndex == 0U || maxColumnCount == 0
+        ? "A1"
+        : $"A1:{ColumnReferenceHelper.ToLetters(maxColumnCount)}{lastRowIndex}";
+      var sheetDimension = new SheetDimension { Reference = reference };
 
       var sheetViews = new SheetViews();
 
@@ -633,8 +641,8 @@ namespace SimpleExcelExporter
         var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
         var sheet = new Sheet { Name = worksheet.Name, SheetId = count, Id = workbookPart.GetIdOfPart(worksheetPart) };
         _ = sheets.AppendChild(sheet);
-        var sheetData = GenerateSheetDataForDetails(worksheet);
-        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U);
+        var (sheetData, maxColumnCount, lastRowIndex) = GenerateSheetDataForDetails(worksheet);
+        GenerateWorksheetPartContent(worksheetPart, sheetData, count == 1U, maxColumnCount, lastRowIndex);
         count++;
       }
     }
@@ -652,13 +660,16 @@ namespace SimpleExcelExporter
       return row;
     }
 
-    private SheetData GenerateSheetDataForDetails(WorksheetDfn worksheet)
+    private (SheetData SheetData, int MaxColumnCount, uint LastRowIndex) GenerateSheetDataForDetails(WorksheetDfn worksheet)
     {
       var sheetData1 = new SheetData();
       var currentRowIndex = 1U;
+      var maxColumnCount = 0;
+
       if (worksheet.ColumnHeadings.Cells.Count > 0)
       {
         _ = sheetData1.AppendChild(CreateHeaderRowForExcel(worksheet.ColumnHeadings.Cells, currentRowIndex));
+        maxColumnCount = worksheet.ColumnHeadings.Cells.Count;
         currentRowIndex++;
       }
 
@@ -666,10 +677,16 @@ namespace SimpleExcelExporter
       {
         var partsRows = GenerateRowForChildPartDetail(row, currentRowIndex);
         _ = sheetData1.AppendChild(partsRows);
+        if (row.Cells.Count > maxColumnCount)
+        {
+          maxColumnCount = row.Cells.Count;
+        }
+
         currentRowIndex++;
       }
 
-      return sheetData1;
+      var lastRowIndex = currentRowIndex - 1U;
+      return (sheetData1, maxColumnCount, lastRowIndex);
     }
 
     private void GenerateWorkbookStylesPartContent(WorkbookStylesPart workbookStylesPart)

--- a/src/SimpleExcelExporter/packages.lock.json
+++ b/src/SimpleExcelExporter/packages.lock.json
@@ -11,6 +11,16 @@
           "DocumentFormat.OpenXml.Framework": "3.5.1"
         }
       },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
       "StyleCop.Analyzers": {
         "type": "Direct",
         "requested": "[1.2.0-beta.556, )",
@@ -27,6 +37,16 @@
         "dependencies": {
           "System.IO.Packaging": "8.0.1"
         }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",

--- a/src/SimpleExcelExporter/packages.lock.json
+++ b/src/SimpleExcelExporter/packages.lock.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "DocumentFormat.OpenXml": {
+        "type": "Direct",
+        "requested": "[3.5.1, )",
+        "resolved": "3.5.1",
+        "contentHash": "zxdOf5VVCe/uNklbRhj8dVBzQGj3DoqkUuqOp9cAZVuN8mNYDjof1lvSQA2OQNr8Ptc9d7pbA7Azq/ReaI3FpA==",
+        "dependencies": {
+          "DocumentFormat.OpenXml.Framework": "3.5.1"
+        }
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "DocumentFormat.OpenXml.Framework": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "U5txtc3ORno73xQx9Lf2gWzfaSZnZwKHfLkTAslhlew9lxe5XbUiCt0dY1fHeAf8yRqszUAe5i/+xLC9R/Xfsw==",
+        "dependencies": {
+          "System.IO.Packaging": "8.0.1"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.IO.Packaging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "KYkIOAvPexQOLDxPO2g0BVoWInnQhPpkFzRqvNrNrMhVT6kqhVr0zEb6KCHlptLFukxnZrjuMVAnxK7pOGUYrw=="
+      }
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/ColumnReferenceHelperTest.cs
+++ b/test/SimpleExcelExporterTests/ColumnReferenceHelperTest.cs
@@ -1,0 +1,32 @@
+namespace SimpleExcelExporter.Tests
+{
+  using NUnit.Framework;
+
+  [TestFixture]
+  public class ColumnReferenceHelperTest
+  {
+    [TestCase(1, "A")]
+    [TestCase(2, "B")]
+    [TestCase(25, "Y")]
+    [TestCase(26, "Z")]
+    [TestCase(27, "AA")]
+    [TestCase(28, "AB")]
+    [TestCase(52, "AZ")]
+    [TestCase(53, "BA")]
+    [TestCase(702, "ZZ")]
+    [TestCase(703, "AAA")]
+    public void ToLetters_ConvertsOneIndexedColumnNumberToA1Letters(int columnIndex, string expected)
+    {
+      var result = ColumnReferenceHelper.ToLetters(columnIndex);
+
+      Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ToLetters_ThrowsForZeroOrNegative()
+    {
+      Assert.Throws<System.ArgumentOutOfRangeException>(() => ColumnReferenceHelper.ToLetters(0));
+      Assert.Throws<System.ArgumentOutOfRangeException>(() => ColumnReferenceHelper.ToLetters(-1));
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/SimpleExcelExporter.Tests.csproj
+++ b/test/SimpleExcelExporterTests/SimpleExcelExporter.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterBehaviorTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterBehaviorTest.cs
@@ -122,14 +122,21 @@ namespace SimpleExcelExporter.Tests
     [Test]
     public void CellValue_NullInAnnotatedObject_ProducesEmptyCell()
     {
-      // PlayerDummyObjectPreparator.First() — the first player in the fixture — has PlayerCode = null.
+      // PlayerDummyObjectPreparator.First() leaves PlayerCode = null. PlayerCode has Index=0 → column A.
+      // The cell at A2 (row 2, first player) must be empty across every library version:
+      //   - master: the cell is emitted with an empty CellValue
+      //   - PR (pre-skip): the cell is emitted as self-closing t="inlineStr"
+      //   - PR (post-skip): the cell is entirely omitted — A2 is empty by position inference
+      // Looking up by r="A2" covers all three cases: if the cell is absent or carries no value,
+      // it is treated as empty.
       var team = TeamDummyObjectPreparator.FirstWithCollections();
       using var stream = WriteToStreamFromObject(team);
       using var doc = SpreadsheetDocument.Open(stream, false);
 
       var cells = GetRowCells(doc, rowIndex: 1); // skip header row, read the first player
-      var playerCode = GetCellString(cells[0], doc.WorkbookPart!);
-      Assert.That(playerCode, Is.Null.Or.Empty, "PlayerCode was null in the source, the cell must be empty");
+      var cellA2 = cells.FirstOrDefault(c => c.CellReference?.Value == "A2");
+      var value = cellA2 != null ? GetCellString(cellA2, doc.WorkbookPart!) : null;
+      Assert.That(value, Is.Null.Or.Empty, "PlayerCode was null in the source, cell A2 must be absent or empty");
     }
 
     [Test]

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterBehaviorTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterBehaviorTest.cs
@@ -1,0 +1,318 @@
+// Behaviour-level tests for SpreadsheetWriter.
+//
+// These tests are DESIGNED TO COMPILE AND PASS ON BOTH master AND
+// fix/xlsx-ooxml-compliance-numbers. They rely only on:
+//   - The public API of SpreadsheetWriter
+//   - The annotation types (CellDefinition, Index, Header, MultiColumn,
+//     SheetName, IgnoreFromSpreadSheet)
+//   - The DocumentFormat.OpenXml SDK for reading the produced file back
+//
+// They do NOT assert any OOXML shape (t="s" vs t="inlineStr" vs t="str",
+// presence of r="A1" on cells, sharedStrings.xml existence, etc.) because
+// those shapes are legitimately different between master and the PR. They
+// focus on semantic behaviour: values preserved, columns ordered, styles
+// deduplicated, ignored properties omitted — invariants that must hold
+// across every implementation.
+//
+// Copy this file as-is into a master checkout to verify that the PR does
+// not regress these behaviours.
+namespace SimpleExcelExporter.Tests
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Globalization;
+  using System.IO;
+  using System.Linq;
+  using DocumentFormat.OpenXml.Packaging;
+  using DocumentFormat.OpenXml.Spreadsheet;
+  using NUnit.Framework;
+  using SimpleExcelExporter.Annotations;
+  using SimpleExcelExporter.Definitions;
+  using SimpleExcelExporter.Tests.Models;
+  using SimpleExcelExporter.Tests.Preparators;
+
+  [TestFixture]
+  public class SpreadSheetWriterBehaviorTest
+  {
+    private static readonly string[] ExpectedMultiSheetNames = ["Alpha", "Beta", "Gamma"];
+
+    [Test]
+    public void CellValue_String_RoundTrip()
+    {
+      var workbook = BuildSingleRowWorkbook(new CellDfn("Hello, world!", cellDataType: CellDataType.String));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      Assert.That(GetCellString(cells[0], doc.WorkbookPart!), Is.EqualTo("Hello, world!"));
+    }
+
+    [Test]
+    public void CellValue_Integer_RoundTrip()
+    {
+      var workbook = BuildSingleRowWorkbook(new CellDfn(42, cellDataType: CellDataType.Number));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      Assert.That(cells[0].CellValue!.InnerText, Is.EqualTo("42"));
+    }
+
+    [Test]
+    public void CellValue_Decimal_PreservesPrecision()
+    {
+      var workbook = BuildSingleRowWorkbook(new CellDfn(12345.6789m, cellDataType: CellDataType.Number));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      Assert.That(decimal.Parse(cells[0].CellValue!.InnerText, CultureInfo.InvariantCulture), Is.EqualTo(12345.6789m));
+    }
+
+    [Test]
+    public void CellValue_Double_RoundTrip()
+    {
+      var workbook = BuildSingleRowWorkbook(new CellDfn(3.14159d, cellDataType: CellDataType.Number));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      Assert.That(double.Parse(cells[0].CellValue!.InnerText, CultureInfo.InvariantCulture), Is.EqualTo(3.14159d).Within(1e-9));
+    }
+
+    [Test]
+    public void CellValue_Boolean_WritesZeroOrOne()
+    {
+      // True -> "0", False -> "1" (matches the library's current convention on both master and PR).
+      var workbookTrue = BuildSingleRowWorkbook(new CellDfn(true, cellDataType: CellDataType.Boolean));
+      var workbookFalse = BuildSingleRowWorkbook(new CellDfn(false, cellDataType: CellDataType.Boolean));
+      using var streamTrue = WriteToStream(workbookTrue);
+      using var streamFalse = WriteToStream(workbookFalse);
+      using var docTrue = SpreadsheetDocument.Open(streamTrue, false);
+      using var docFalse = SpreadsheetDocument.Open(streamFalse, false);
+
+      Assert.That(GetRowCells(docTrue)[0].CellValue!.InnerText, Is.EqualTo("0"));
+      Assert.That(GetRowCells(docFalse)[0].CellValue!.InnerText, Is.EqualTo("1"));
+    }
+
+    [Test]
+    public void CellValue_DateTime_RoundTrip()
+    {
+      var date = new DateTime(2020, 1, 15, 12, 0, 0);
+      var workbook = BuildSingleRowWorkbook(new CellDfn(date, cellDataType: CellDataType.Date));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      var parsed = DateTime.Parse(cells[0].CellValue!.InnerText, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+      Assert.That(parsed, Is.EqualTo(date));
+    }
+
+    [Test]
+    public void CellValue_TimeSpan_WritesFractionOfDay()
+    {
+      var workbook = BuildSingleRowWorkbook(new CellDfn(new TimeSpan(12, 0, 0), cellDataType: CellDataType.Time));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc);
+      Assert.That(double.Parse(cells[0].CellValue!.InnerText, CultureInfo.InvariantCulture), Is.EqualTo(0.5d).Within(1e-9));
+    }
+
+    [Test]
+    public void CellValue_NullInAnnotatedObject_ProducesEmptyCell()
+    {
+      // PlayerDummyObjectPreparator.First() — the first player in the fixture — has PlayerCode = null.
+      var team = TeamDummyObjectPreparator.FirstWithCollections();
+      using var stream = WriteToStreamFromObject(team);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cells = GetRowCells(doc, rowIndex: 1); // skip header row, read the first player
+      var playerCode = GetCellString(cells[0], doc.WorkbookPart!);
+      Assert.That(playerCode, Is.Null.Or.Empty, "PlayerCode was null in the source, the cell must be empty");
+    }
+
+    [Test]
+    public void StyleIndex_DeduplicatesIdenticalCellDataType()
+    {
+      // Twenty cells of CellDataType.Date should share a single style entry.
+      var row = new RowDfn();
+      for (var i = 0; i < 20; i++)
+      {
+        row.Cells.Add(new CellDfn(new DateTime(2020, 1, 1).AddDays(i), cellDataType: CellDataType.Date));
+      }
+
+      var workbook = new WorkbookDfn();
+      var worksheet = new WorksheetDfn("Sheet1");
+      worksheet.Rows.Add(row);
+      workbook.Worksheets.Add(worksheet);
+
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+      var cellFormats = doc.WorkbookPart!.WorkbookStylesPart!.Stylesheet!.CellFormats!.Elements<CellFormat>().ToList();
+
+      var usedDateStyleIndices = doc.WorkbookPart.WorksheetParts
+        .SelectMany(ws => ws.Worksheet!.Descendants<Cell>())
+        .Select(c => c.StyleIndex?.Value ?? 0U)
+        .Distinct()
+        .ToList();
+
+      // All 20 date cells share the same style index; worksheet may have others
+      // implicitly (default 0 for the sheet, but only 1 distinct for Date cells).
+      var dateFormats = cellFormats.Where(cf => cf.NumberFormatId?.Value == 14U).ToList();
+      Assert.That(dateFormats.Count, Is.EqualTo(1), "Expected exactly one CellFormat with numFmtId=14 (Date), found " + dateFormats.Count);
+    }
+
+    [TestCase(CellDataType.Date, 14U)]
+    [TestCase(CellDataType.String, 49U)]
+    [TestCase(CellDataType.Percentage, 10U)]
+    [TestCase(CellDataType.Time, 20U)]
+    public void NumberFormatId_CellDataType_MapsToExpectedId(CellDataType dataType, uint expectedNumFmtId)
+    {
+      object value = dataType switch
+      {
+        CellDataType.Date => new DateTime(2020, 1, 1),
+        CellDataType.String => "x",
+        CellDataType.Percentage => 0.5d,
+        CellDataType.Time => new TimeSpan(1, 0, 0),
+        _ => 0,
+      };
+
+      var workbook = BuildSingleRowWorkbook(new CellDfn(value, cellDataType: dataType));
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var cell = doc.WorkbookPart!.WorksheetParts.First().Worksheet!.Descendants<Cell>().First();
+      var styleIndex = cell.StyleIndex?.Value ?? 0U;
+      var format = doc.WorkbookPart.WorkbookStylesPart!.Stylesheet!.CellFormats!.Elements<CellFormat>().ElementAt((int)styleIndex);
+
+      Assert.That(format.NumberFormatId?.Value, Is.EqualTo(expectedNumFmtId));
+    }
+
+    [Test]
+    public void IgnoreFromSpreadSheet_OmitsAnnotatedProperty()
+    {
+      // ChildOfPlayerDummyObject has HeaderMention tagged [IgnoreFromSpreadSheet].
+      // When a player with Children is written, HeaderMention must not appear as a column.
+      var team = TeamDummyObjectPreparator.FirstWithCollections();
+      using var stream = WriteToStreamFromObject(team);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var firstSheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet!;
+      var headerRow = firstSheet.Descendants<Row>().First();
+      var headerTexts = headerRow.Descendants<Cell>()
+        .Select(c => GetCellString(c, doc.WorkbookPart))
+        .ToList();
+
+      Assert.That(headerTexts, Has.None.EqualTo("HeaderMention"), "A property tagged [IgnoreFromSpreadSheet] must not produce a column");
+    }
+
+    [Test]
+    public void MultipleWorksheets_PreservesSheetNamesAndOrder()
+    {
+      var workbook = new WorkbookDfn();
+      workbook.Worksheets.Add(MakeSheetWithOneValueRow("Alpha", "a"));
+      workbook.Worksheets.Add(MakeSheetWithOneValueRow("Beta", "b"));
+      workbook.Worksheets.Add(MakeSheetWithOneValueRow("Gamma", "c"));
+
+      using var stream = WriteToStream(workbook);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+      var sheets = doc.WorkbookPart!.Workbook!.Sheets!.Elements<Sheet>().ToList();
+
+      Assert.That(sheets.Count, Is.EqualTo(3));
+      Assert.That(sheets.Select(s => s.Name?.Value).ToList(), Is.EqualTo(ExpectedMultiSheetNames));
+    }
+
+    [Test]
+    public void IndexAttribute_OrdersColumnsByIndex()
+    {
+      // PlayerDummyObject has PlayerCode(Index=0), PlayerName(Index=1), DateOfBirth(Index=2), …
+      var team = TeamDummyObjectPreparator.FirstWithCollections();
+      using var stream = WriteToStreamFromObject(team);
+      using var doc = SpreadsheetDocument.Open(stream, false);
+
+      var firstSheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet!;
+      var headerRow = firstSheet.Descendants<Row>().First();
+      var headers = headerRow.Descendants<Cell>()
+        .Select(c => GetCellString(c, doc.WorkbookPart))
+        .ToList();
+
+      // The first three columns must come from Index=0,1,2 = PlayerCode, PlayerName, DateOfBirth.
+      // Exact header values come from PlayerDummyObjectRes resources; we only check the relative
+      // order matches the IndexAttribute assignment.
+      Assert.That(headers[0], Is.Not.Null.And.Not.Empty);
+      Assert.That(headers[1], Is.Not.Null.And.Not.Empty);
+      Assert.That(headers[2], Is.Not.Null.And.Not.Empty);
+
+      // The Player.PlayerCode property has Index 0 so its header is first.
+      // Its resource value 'Player code' is stable across master and PR.
+      Assert.That(headers[0], Does.Contain("code").IgnoreCase, "First column should correspond to PlayerCode (Index=0)");
+    }
+
+    // Helpers
+
+    private static WorksheetDfn MakeSheetWithOneValueRow(string sheetName, string value)
+    {
+      var sheet = new WorksheetDfn(sheetName);
+      var row = new RowDfn();
+      row.Cells.Add(new CellDfn(value, cellDataType: CellDataType.String));
+      sheet.Rows.Add(row);
+      return sheet;
+    }
+
+    private static WorkbookDfn BuildSingleRowWorkbook(CellDfn cell)
+    {
+      var workbook = new WorkbookDfn();
+      var sheet = new WorksheetDfn("Sheet1");
+      var row = new RowDfn();
+      row.Cells.Add(cell);
+      sheet.Rows.Add(row);
+      workbook.Worksheets.Add(sheet);
+      return workbook;
+    }
+
+    private static MemoryStream WriteToStream(WorkbookDfn workbook)
+    {
+      var stream = new MemoryStream();
+      var writer = new SpreadsheetWriter(stream, workbook);
+      writer.Write();
+      stream.Position = 0;
+      return stream;
+    }
+
+    private static MemoryStream WriteToStreamFromObject(object annotated)
+    {
+      var stream = new MemoryStream();
+      var writer = new SpreadsheetWriter(stream, annotated);
+      writer.Write();
+      stream.Position = 0;
+      return stream;
+    }
+
+    private static List<Cell> GetRowCells(SpreadsheetDocument doc, int rowIndex = 0)
+    {
+      var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet!;
+      var rows = sheet.Descendants<Row>().ToList();
+      return rows[rowIndex].Descendants<Cell>().ToList();
+    }
+
+    private static string? GetCellString(Cell cell, WorkbookPart workbookPart)
+    {
+      // Handles every string representation: t="str" (master), t="inlineStr" (PR pre-shared),
+      // t="s" (PR post-shared), and the implicit inline CellValue text fallback.
+      if (cell.DataType?.Value == CellValues.SharedString && cell.CellValue != null)
+      {
+        var index = int.Parse(cell.CellValue.InnerText, CultureInfo.InvariantCulture);
+        var sharedTable = workbookPart.SharedStringTablePart?.SharedStringTable;
+        return sharedTable?.ElementAt(index).InnerText;
+      }
+
+      if (cell.DataType?.Value == CellValues.InlineString && cell.InlineString != null)
+      {
+        return cell.InlineString.InnerText;
+      }
+
+      return cell.CellValue?.InnerText;
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -3,6 +3,7 @@ namespace SimpleExcelExporter.Tests
   using System.IO;
   using System.IO.Compression;
   using System.Linq;
+  using System.Text;
   using System.Xml.Linq;
   using NUnit.Framework;
   using SimpleExcelExporter.Tests.Preparators.Definitions;
@@ -77,6 +78,48 @@ namespace SimpleExcelExporter.Tests
 
       var overrideForSheet1 = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/worksheets/sheet1.xml");
       Assert.That(overrideForSheet1, Is.Not.Null, "Expected a <Override> for /xl/worksheets/sheet1.xml");
+    }
+
+    [Test]
+    public void StringCells_UseInlineString_NotStr()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var strCells = sheetXml.Descendants(ns + "c")
+        .Where(c => (string?)c.Attribute("t") == "str")
+        .ToList();
+      Assert.That(strCells, Is.Empty, "No cell should use t=\"str\" (reserved for formula results)");
+
+      var inlineStrCells = sheetXml.Descendants(ns + "c")
+        .Where(c => (string?)c.Attribute("t") == "inlineStr")
+        .ToList();
+      Assert.That(inlineStrCells, Is.Not.Empty, "String cells should use t=\"inlineStr\"");
+
+      // Verify inlineStr cells have <is><t>...</t></is> structure, not <v>
+      foreach (var cell in inlineStrCells)
+      {
+        var inlineString = cell.Element(ns + "is");
+        Assert.That(inlineString, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is> element");
+        var text = inlineString!.Element(ns + "t");
+        Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
+        Assert.That(cell.Element(ns + "v"), Is.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must NOT have <v> element");
+      }
+    }
+
+    [Test]
+    public void Worksheet_UsesDefaultNamespace()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
+      Assert.That(entry, Is.Not.Null, "Missing xl/worksheets/sheet1.xml");
+      using var stream = entry!.Open();
+      using var reader = new StreamReader(stream, Encoding.UTF8);
+      var content = reader.ReadToEnd();
+
+      Assert.That(content, Does.Not.Contain("xmlns:x="), "Worksheet should use default namespace, not x: prefix");
+      Assert.That(content, Does.Contain("xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""), "Worksheet should declare SpreadsheetML namespace as default");
+      Assert.That(content, Does.Not.Contain("<x:"), "Worksheet should not use x: prefix on any element");
     }
 
     private static XDocument LoadContentTypesXml()

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -15,6 +15,8 @@ namespace SimpleExcelExporter.Tests
 
     private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
 
+    private const string PackageRelationshipsNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
+
     [Test]
     public void RowsAndCells_HaveReferenceAttributes()
     {
@@ -105,6 +107,69 @@ namespace SimpleExcelExporter.Tests
         {
           var text = inlineString.Element(ns + "t");
           Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
+        }
+      }
+    }
+
+    [Test]
+    public void ContentTypes_AllDefaultsAppearBeforeAnyOverride()
+    {
+      // Strict OOXML parsers expect every <Default> entry to appear before the first <Override>.
+      // The schema technically allows interleaving, but tools like Apple Numbers reject it.
+      var contentTypesXml = LoadContentTypesXml();
+      var ns = XNamespace.Get(ContentTypesNamespace);
+
+      var children = contentTypesXml.Root!.Elements().ToList();
+      var lastDefaultIndex = -1;
+      var firstOverrideIndex = -1;
+      for (var i = 0; i < children.Count; i++)
+      {
+        if (children[i].Name == ns + "Default")
+        {
+          lastDefaultIndex = i;
+        }
+        else if (children[i].Name == ns + "Override" && firstOverrideIndex == -1)
+        {
+          firstOverrideIndex = i;
+        }
+      }
+
+      Assert.That(lastDefaultIndex, Is.GreaterThanOrEqualTo(0), "Expected at least one <Default> element");
+      Assert.That(firstOverrideIndex, Is.GreaterThanOrEqualTo(0), "Expected at least one <Override> element");
+      Assert.That(
+        lastDefaultIndex,
+        Is.LessThan(firstOverrideIndex),
+        "All <Default> elements must appear before any <Override> element");
+    }
+
+    [Test]
+    public void RelationshipTargets_AreRelative()
+    {
+      // Apple Numbers rejects .rels files whose <Relationship Target="..."> starts with '/'.
+      // All targets must be relative paths. Applies to both _rels/.rels (package-level) and
+      // xl/_rels/workbook.xml.rels (workbook-level).
+      var relsNs = XNamespace.Get(PackageRelationshipsNamespace);
+      using var archive = GenerateAndOpenXlsxArchive();
+
+      foreach (var relsPath in new[] { "_rels/.rels", "xl/_rels/workbook.xml.rels" })
+      {
+        var entry = archive.GetEntry(relsPath);
+        Assert.That(entry, Is.Not.Null, $"Missing {relsPath} in the generated package");
+        using var stream = entry!.Open();
+        var doc = XDocument.Load(stream);
+
+        var relationships = doc.Descendants(relsNs + "Relationship").ToList();
+        Assert.That(relationships, Is.Not.Empty, $"{relsPath} should contain at least one <Relationship>");
+
+        foreach (var rel in relationships)
+        {
+          var target = rel.Attribute("Target")?.Value;
+          var id = rel.Attribute("Id")?.Value;
+          Assert.That(target, Is.Not.Null.And.Not.Empty, $"{relsPath}: Relationship {id} must have a non-empty Target");
+          Assert.That(
+            target,
+            Does.Not.StartWith("/"),
+            $"{relsPath}: Relationship {id} target '{target}' must be relative (no leading '/')");
         }
       }
     }

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -1,0 +1,109 @@
+namespace SimpleExcelExporter.Tests
+{
+  using System.IO;
+  using System.IO.Compression;
+  using System.Linq;
+  using System.Xml.Linq;
+  using NUnit.Framework;
+  using SimpleExcelExporter.Tests.Preparators.Definitions;
+
+  [TestFixture]
+  public class SpreadSheetWriterOoxmlComplianceTest
+  {
+    private const string SpreadsheetMlNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private const string ContentTypesNamespace = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    [Test]
+    public void RowsAndCells_HaveReferenceAttributes()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var rows = sheetXml.Descendants(ns + "row").ToList();
+      Assert.That(rows, Is.Not.Empty, "Expected at least one <row> element");
+
+      uint expectedRowIndex = 1U;
+      foreach (var row in rows)
+      {
+        var rowRef = row.Attribute("r");
+        Assert.That(rowRef, Is.Not.Null, $"Row at position {expectedRowIndex} is missing the 'r' attribute");
+        Assert.That(rowRef!.Value, Is.EqualTo(expectedRowIndex.ToString()), "Row 'r' attribute should be 1-indexed and contiguous");
+
+        var columnIndex = 1;
+        foreach (var cell in row.Elements(ns + "c"))
+        {
+          var cellRef = cell.Attribute("r");
+          Assert.That(cellRef, Is.Not.Null, $"Cell at row {expectedRowIndex} column {columnIndex} is missing the 'r' attribute");
+          var expected = $"{ColumnReferenceHelper.ToLetters(columnIndex)}{expectedRowIndex}";
+          Assert.That(cellRef!.Value, Is.EqualTo(expected), $"Cell reference mismatch at row {expectedRowIndex} column {columnIndex}");
+          columnIndex++;
+        }
+
+        expectedRowIndex++;
+      }
+    }
+
+    [Test]
+    public void SheetDimension_MatchesUsedRange()
+    {
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      // Fixture FirstFirstWithCollections: 7 columns (A..G), 1 header row + 3 data rows = A1:G4
+      var dimension = sheetXml.Descendants(ns + "dimension").SingleOrDefault();
+      Assert.That(dimension, Is.Not.Null, "Expected a <dimension> element in the worksheet");
+      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:G4"));
+    }
+
+    [Test]
+    public void ContentTypes_DefaultXmlExtension_IsGenericApplicationXml()
+    {
+      var contentTypesXml = LoadContentTypesXml();
+      var ns = XNamespace.Get(ContentTypesNamespace);
+
+      var defaultXml = contentTypesXml.Descendants(ns + "Default").SingleOrDefault(d => (string?)d.Attribute("Extension") == "xml");
+      Assert.That(defaultXml, Is.Not.Null, "Expected a <Default Extension='xml'> entry");
+      Assert.That(defaultXml!.Attribute("ContentType")?.Value, Is.EqualTo("application/xml"), "Default xml extension must be generic application/xml");
+
+      var overrides = contentTypesXml.Descendants(ns + "Override").ToList();
+      var overrideForCore = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/docProps/core.xml");
+      Assert.That(overrideForCore, Is.Not.Null, "Expected a <Override> for /docProps/core.xml");
+      Assert.That(overrideForCore!.Attribute("ContentType")?.Value, Is.EqualTo("application/vnd.openxmlformats-package.core-properties+xml"));
+
+      var overrideForWorkbook = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/workbook.xml");
+      Assert.That(overrideForWorkbook, Is.Not.Null, "Expected a <Override> for /xl/workbook.xml");
+
+      var overrideForSheet1 = overrides.SingleOrDefault(o => (string?)o.Attribute("PartName") == "/xl/worksheets/sheet1.xml");
+      Assert.That(overrideForSheet1, Is.Not.Null, "Expected a <Override> for /xl/worksheets/sheet1.xml");
+    }
+
+    private static XDocument LoadContentTypesXml()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("[Content_Types].xml");
+      Assert.That(entry, Is.Not.Null, "Missing [Content_Types].xml in the generated package");
+      using var stream = entry!.Open();
+      return XDocument.Load(stream);
+    }
+
+    private static XDocument LoadSheetXml()
+    {
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
+      Assert.That(entry, Is.Not.Null, "Missing xl/worksheets/sheet1.xml in the generated package");
+      using var stream = entry!.Open();
+      return XDocument.Load(stream);
+    }
+
+    private static ZipArchive GenerateAndOpenXlsxArchive()
+    {
+      var workbook = WorkbookDfnPreparator.FirstFirstWithCollections();
+      var memory = new MemoryStream();
+      var writer = new SpreadsheetWriter(memory, workbook);
+      writer.Write();
+      memory.Position = 0;
+      return new ZipArchive(memory, ZipArchiveMode.Read, leaveOpen: false);
+    }
+  }
+}

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -96,14 +96,16 @@ namespace SimpleExcelExporter.Tests
         .ToList();
       Assert.That(inlineStrCells, Is.Not.Empty, "String cells should use t=\"inlineStr\"");
 
-      // Verify inlineStr cells have <is><t>...</t></is> structure, not <v>
+      // Verify inlineStr cells: non-empty ones must have <is><t>...</t></is>, none should have <v>
       foreach (var cell in inlineStrCells)
       {
-        var inlineString = cell.Element(ns + "is");
-        Assert.That(inlineString, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is> element");
-        var text = inlineString!.Element(ns + "t");
-        Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
         Assert.That(cell.Element(ns + "v"), Is.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must NOT have <v> element");
+        var inlineString = cell.Element(ns + "is");
+        if (inlineString != null)
+        {
+          var text = inlineString.Element(ns + "t");
+          Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
+        }
       }
     }
 

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -50,10 +50,11 @@ namespace SimpleExcelExporter.Tests
       var sheetXml = LoadSheetXml();
       var ns = XNamespace.Get(SpreadsheetMlNamespace);
 
-      // Fixture FirstFirstWithCollections: 7 columns (A..G), 1 header row + 3 data rows = A1:G4
+      // Fixture FirstFirstWithCollections: header has 7 columns (A..G) but row3 has 8 cells (A..H).
+      // maxColumnCount = max(7, 7, 7, 8) = 8 → used range is A1:H4.
       var dimension = sheetXml.Descendants(ns + "dimension").SingleOrDefault();
       Assert.That(dimension, Is.Not.Null, "Expected a <dimension> element in the worksheet");
-      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:G4"));
+      Assert.That(dimension!.Attribute("ref")?.Value, Is.EqualTo("A1:H4"));
     }
 
     [Test]

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -110,6 +110,33 @@ namespace SimpleExcelExporter.Tests
     }
 
     [Test]
+    public void EmptyInlineStrCell_IsSelfClosingWithoutIsChild()
+    {
+      // Fixture FirstFirstWithCollections: row3 column G is new CellDfn(string.Empty, CellDataType.String),
+      // which becomes cell G4 (row 4 after the header row). Apple Numbers requires empty inlineStr
+      // cells to be self-closing with no <is> child (not <c t="inlineStr"><is/></c> or similar).
+      var sheetXml = LoadSheetXml();
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var emptyCell = sheetXml.Descendants(ns + "c")
+        .SingleOrDefault(c => (string?)c.Attribute("r") == "G4");
+      Assert.That(emptyCell, Is.Not.Null, "Expected cell G4 (the empty string cell from the fixture)");
+      Assert.That(emptyCell!.Attribute("t")?.Value, Is.EqualTo("inlineStr"), "G4 should declare t=\"inlineStr\"");
+      Assert.That(emptyCell.Elements().Any(), Is.False, "Empty inlineStr cell must have no child element (no <is>, no <v>)");
+      Assert.That(emptyCell.Value, Is.Empty, "Empty inlineStr cell must have no text content");
+
+      using var archive = GenerateAndOpenXlsxArchive();
+      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
+      using var stream = entry!.Open();
+      using var reader = new StreamReader(stream, Encoding.UTF8);
+      var content = reader.ReadToEnd();
+      Assert.That(
+        content,
+        Does.Match("<c [^>]*r=\"G4\"[^>]*/>"),
+        "Empty inlineStr cell G4 must be emitted as a self-closing element");
+    }
+
+    [Test]
     public void Worksheet_UsesDefaultNamespace()
     {
       using var archive = GenerateAndOpenXlsxArchive();

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -1,5 +1,6 @@
 namespace SimpleExcelExporter.Tests
 {
+  using System.Globalization;
   using System.IO;
   using System.IO.Compression;
   using System.Linq;
@@ -83,31 +84,75 @@ namespace SimpleExcelExporter.Tests
     }
 
     [Test]
-    public void StringCells_UseInlineString_NotStr()
+    public void StringCells_UseSharedStringsOrEmptyInlineStr()
     {
       var sheetXml = LoadSheetXml();
       var ns = XNamespace.Get(SpreadsheetMlNamespace);
 
+      // t="str" is reserved for formula results — never used by this writer.
       var strCells = sheetXml.Descendants(ns + "c")
         .Where(c => (string?)c.Attribute("t") == "str")
         .ToList();
       Assert.That(strCells, Is.Empty, "No cell should use t=\"str\" (reserved for formula results)");
 
+      // Non-empty strings go through the shared strings table: t="s", <v>index</v>, no <is>.
+      var sharedCells = sheetXml.Descendants(ns + "c")
+        .Where(c => (string?)c.Attribute("t") == "s")
+        .ToList();
+      Assert.That(sharedCells, Is.Not.Empty, "Non-empty string cells should reference the shared strings table with t=\"s\"");
+
+      foreach (var cell in sharedCells)
+      {
+        Assert.That(cell.Element(ns + "is"), Is.Null, $"t=\"s\" cell {cell.Attribute("r")?.Value} must NOT have <is> element");
+        var value = cell.Element(ns + "v");
+        Assert.That(value, Is.Not.Null, $"t=\"s\" cell {cell.Attribute("r")?.Value} must have <v> element with index");
+        Assert.That(int.TryParse(value!.Value, out _), Is.True, $"t=\"s\" cell {cell.Attribute("r")?.Value} value must be an integer index");
+      }
+
+      // Empty strings remain as self-closing t="inlineStr" — see EmptyInlineStrCell_IsSelfClosingWithoutIsChild.
       var inlineStrCells = sheetXml.Descendants(ns + "c")
         .Where(c => (string?)c.Attribute("t") == "inlineStr")
         .ToList();
-      Assert.That(inlineStrCells, Is.Not.Empty, "String cells should use t=\"inlineStr\"");
-
-      // Verify inlineStr cells: non-empty ones must have <is><t>...</t></is>, none should have <v>
       foreach (var cell in inlineStrCells)
       {
-        Assert.That(cell.Element(ns + "v"), Is.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must NOT have <v> element");
-        var inlineString = cell.Element(ns + "is");
-        if (inlineString != null)
-        {
-          var text = inlineString.Element(ns + "t");
-          Assert.That(text, Is.Not.Null, $"inlineStr cell {cell.Attribute("r")?.Value} must have <is><t> element");
-        }
+        Assert.That(cell.Elements().Any(), Is.False, $"inlineStr cell {cell.Attribute("r")?.Value} must be empty (self-closing)");
+      }
+    }
+
+    [Test]
+    public void SharedStringsTable_IsConsistentWithCellReferences()
+    {
+      // Load sharedStrings.xml and verify every t="s" cell's index is within bounds, count/uniqueCount are sane.
+      using var archive = GenerateAndOpenXlsxArchive();
+      var sharedEntry = archive.GetEntry("xl/sharedStrings.xml");
+      Assert.That(sharedEntry, Is.Not.Null, "Missing xl/sharedStrings.xml");
+      using var sharedStream = sharedEntry!.Open();
+      var sharedDoc = XDocument.Load(sharedStream);
+      var ns = XNamespace.Get(SpreadsheetMlNamespace);
+
+      var sst = sharedDoc.Root!;
+      Assert.That(sst.Name, Is.EqualTo(ns + "sst"), "Root element of sharedStrings.xml must be <sst>");
+
+      var items = sst.Elements(ns + "si").ToList();
+      var uniqueCount = int.Parse(sst.Attribute("uniqueCount")!.Value, CultureInfo.InvariantCulture);
+      Assert.That(uniqueCount, Is.EqualTo(items.Count), "uniqueCount attribute must match the number of <si> children");
+
+      // Verify every <si><t> has non-empty text (empty strings go inline, not to the table).
+      foreach (var si in items)
+      {
+        var text = si.Element(ns + "t");
+        Assert.That(text, Is.Not.Null, "<si> must contain a <t> element");
+        Assert.That(string.IsNullOrEmpty(text!.Value), Is.False, "<si><t> must not be empty — empty strings belong in inline cells");
+      }
+
+      // Verify every t="s" cell references a valid index.
+      var sheetXml = LoadSheetXml();
+      var sharedCells = sheetXml.Descendants(ns + "c").Where(c => (string?)c.Attribute("t") == "s").ToList();
+      Assert.That(sharedCells, Is.Not.Empty);
+      foreach (var cell in sharedCells)
+      {
+        var index = int.Parse(cell.Element(ns + "v")!.Value, CultureInfo.InvariantCulture);
+        Assert.That(index, Is.InRange(0, items.Count - 1), $"Cell {cell.Attribute("r")?.Value} references index {index}, out of range");
       }
     }
 

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterOoxmlComplianceTest.cs
@@ -21,6 +21,10 @@ namespace SimpleExcelExporter.Tests
     [Test]
     public void RowsAndCells_HaveReferenceAttributes()
     {
+      // Every emitted row carries r="N" and every emitted cell carries r="A1" with the correct
+      // row number. Because empty cells are omitted, column indices are not contiguous — we only
+      // verify that each cell's reference matches its actual position and that positions are
+      // strictly increasing within a row.
       var sheetXml = LoadSheetXml();
       var ns = XNamespace.Get(SpreadsheetMlNamespace);
 
@@ -34,18 +38,35 @@ namespace SimpleExcelExporter.Tests
         Assert.That(rowRef, Is.Not.Null, $"Row at position {expectedRowIndex} is missing the 'r' attribute");
         Assert.That(rowRef!.Value, Is.EqualTo(expectedRowIndex.ToString()), "Row 'r' attribute should be 1-indexed and contiguous");
 
-        var columnIndex = 1;
+        var lastColumnIndex = 0;
         foreach (var cell in row.Elements(ns + "c"))
         {
           var cellRef = cell.Attribute("r");
-          Assert.That(cellRef, Is.Not.Null, $"Cell at row {expectedRowIndex} column {columnIndex} is missing the 'r' attribute");
-          var expected = $"{ColumnReferenceHelper.ToLetters(columnIndex)}{expectedRowIndex}";
-          Assert.That(cellRef!.Value, Is.EqualTo(expected), $"Cell reference mismatch at row {expectedRowIndex} column {columnIndex}");
-          columnIndex++;
+          Assert.That(cellRef, Is.Not.Null, $"Cell in row {expectedRowIndex} is missing the 'r' attribute");
+
+          var letters = new string(cellRef!.Value.TakeWhile(char.IsLetter).ToArray());
+          var rowPart = cellRef.Value[letters.Length ..];
+          Assert.That(letters, Is.Not.Empty, $"Cell reference '{cellRef.Value}' has no column letters");
+          Assert.That(rowPart, Is.EqualTo(expectedRowIndex.ToString()), $"Cell reference '{cellRef.Value}' does not match row {expectedRowIndex}");
+
+          var columnIndex = LettersToColumnIndex(letters);
+          Assert.That(columnIndex, Is.GreaterThan(lastColumnIndex), "Cells must appear in strictly increasing column order within a row");
+          lastColumnIndex = columnIndex;
         }
 
         expectedRowIndex++;
       }
+    }
+
+    private static int LettersToColumnIndex(string letters)
+    {
+      var result = 0;
+      foreach (var c in letters)
+      {
+        result = (result * 26) + (c - 'A' + 1);
+      }
+
+      return result;
     }
 
     [Test]
@@ -220,30 +241,24 @@ namespace SimpleExcelExporter.Tests
     }
 
     [Test]
-    public void EmptyInlineStrCell_IsSelfClosingWithoutIsChild()
+    public void EmptyCell_IsOmittedFromOutput()
     {
-      // Fixture FirstFirstWithCollections: row3 column G is new CellDfn(string.Empty, CellDataType.String),
-      // which becomes cell G4 (row 4 after the header row). Apple Numbers requires empty inlineStr
-      // cells to be self-closing with no <is> child (not <c t="inlineStr"><is/></c> or similar).
+      // Fixture FirstFirstWithCollections: row3 column G is new CellDfn(string.Empty, CellDataType.String).
+      // The library omits cells with no content entirely — OOXML readers infer empty positions
+      // from the 'r' attribute of surrounding cells. This is also what Excel emits natively and is
+      // accepted by Apple Numbers.
       var sheetXml = LoadSheetXml();
       var ns = XNamespace.Get(SpreadsheetMlNamespace);
 
-      var emptyCell = sheetXml.Descendants(ns + "c")
+      var cellG4 = sheetXml.Descendants(ns + "c")
         .SingleOrDefault(c => (string?)c.Attribute("r") == "G4");
-      Assert.That(emptyCell, Is.Not.Null, "Expected cell G4 (the empty string cell from the fixture)");
-      Assert.That(emptyCell!.Attribute("t")?.Value, Is.EqualTo("inlineStr"), "G4 should declare t=\"inlineStr\"");
-      Assert.That(emptyCell.Elements().Any(), Is.False, "Empty inlineStr cell must have no child element (no <is>, no <v>)");
-      Assert.That(emptyCell.Value, Is.Empty, "Empty inlineStr cell must have no text content");
+      Assert.That(cellG4, Is.Null, "Empty cell G4 must not appear in the output; its position is inferred from F4 and H4");
 
-      using var archive = GenerateAndOpenXlsxArchive();
-      var entry = archive.GetEntry("xl/worksheets/sheet1.xml");
-      using var stream = entry!.Open();
-      using var reader = new StreamReader(stream, Encoding.UTF8);
-      var content = reader.ReadToEnd();
-      Assert.That(
-        content,
-        Does.Match("<c [^>]*r=\"G4\"[^>]*/>"),
-        "Empty inlineStr cell G4 must be emitted as a self-closing element");
+      // Sanity: the neighbouring cells should still be present to bracket the missing G4.
+      var cellF4 = sheetXml.Descendants(ns + "c").SingleOrDefault(c => (string?)c.Attribute("r") == "F4");
+      var cellH4 = sheetXml.Descendants(ns + "c").SingleOrDefault(c => (string?)c.Attribute("r") == "H4");
+      Assert.That(cellF4, Is.Not.Null, "Expected cell F4 to be present (non-empty in the fixture)");
+      Assert.That(cellH4, Is.Not.Null, "Expected cell H4 to be present (non-empty in the fixture)");
     }
 
     [Test]

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
@@ -85,8 +85,10 @@ namespace SimpleExcelExporter.Tests
 
       // Check
       Assert.That(memoryStream.Length, Is.Not.EqualTo(0));
-      // expected 1 sheet, 4 rows (1 header + 3 players), 3 cells
-      Validate(memoryStream, 1, 4, 4);
+      // expected 1 sheet, 4 rows (1 header + 3 players), 3 cells in the header row.
+      // PlayerWithSameColumnIndexDummyObject.FourthColumn has no [Header] attribute, so its
+      // empty header cell is omitted from the output (the library skips cells with no content).
+      Validate(memoryStream, 1, 4, 3);
 
       // Prepare with object - with same sheet
       var teamWithSameSheetName = TeamWithSameSheetNameDummyObjectPreparator.First();

--- a/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
+++ b/test/SimpleExcelExporterTests/SpreadSheetWriterTest.cs
@@ -137,12 +137,12 @@ namespace SimpleExcelExporter.Tests
 
       var workbookPart = spreadsheetDocument.WorkbookPart;
       var worksheetsPart = workbookPart!.WorksheetParts.First();
-      var sheetData = worksheetsPart.Worksheet.GetFirstChild<SheetData>();
+      var sheetData = worksheetsPart.Worksheet!.GetFirstChild<SheetData>();
       var rows = sheetData!.Descendants<Row>().ToList();
       var cells = rows[0].Descendants<Cell>();
 
       Assert.That(workbookPart.Workbook, Is.Not.Null);
-      Assert.That(workbookPart.Workbook.Sheets, Is.Not.Null);
+      Assert.That(workbookPart.Workbook!.Sheets, Is.Not.Null);
       Assert.That(expectedSheetsCount, Is.EqualTo(workbookPart.Workbook.Sheets!.Count()));
       Assert.That(expectedRowsCount, Is.EqualTo(rows.Count));
       Assert.That(expectedCellsCount, Is.EqualTo(cells.Count()));

--- a/test/SimpleExcelExporterTests/packages.lock.json
+++ b/test/SimpleExcelExporterTests/packages.lock.json
@@ -1,0 +1,88 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.12.0, )",
+        "resolved": "17.12.0",
+        "contentHash": "kt/PKBZ91rFCWxVIJZSgVLk+YR+4KxTuHf799ho8WNiK5ZQpJNAEZCAWX86vcKrs+DiYjiibpYKdGZP6+/N17w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.12.0",
+          "Microsoft.TestPlatform.TestHost": "17.12.0"
+        }
+      },
+      "NUnit": {
+        "type": "Direct",
+        "requested": "[4.2.2, )",
+        "resolved": "4.2.2",
+        "contentHash": "mon0OPko28yZ/foVXrhiUvq1LReaGsBdziumyyYGxV/pOE4q92fuYeN+AF+gEU5pCjzykcdBt5l7xobTaiBjsg=="
+      },
+      "NUnit3TestAdapter": {
+        "type": "Direct",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "R7e1+a4vuV/YS+ItfL7f//rG+JBvVeVLX4mHzFEZo4W1qEKl8Zz27AqvQSAqo+BtIzUCo4aAJMYa56VXS4hudw=="
+      },
+      "DocumentFormat.OpenXml": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "zxdOf5VVCe/uNklbRhj8dVBzQGj3DoqkUuqOp9cAZVuN8mNYDjof1lvSQA2OQNr8Ptc9d7pbA7Azq/ReaI3FpA==",
+        "dependencies": {
+          "DocumentFormat.OpenXml.Framework": "3.5.1"
+        }
+      },
+      "DocumentFormat.OpenXml.Framework": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "U5txtc3ORno73xQx9Lf2gWzfaSZnZwKHfLkTAslhlew9lxe5XbUiCt0dY1fHeAf8yRqszUAe5i/+xLC9R/Xfsw==",
+        "dependencies": {
+          "System.IO.Packaging": "8.0.1"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.12.0",
+        "contentHash": "4svMznBd5JM21JIG2xZKGNanAHNXplxf/kQDFfLHXQ3OnpJkayRK/TjacFjA+EYmoyuNXHo/sOETEfcYtAzIrA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.12.0",
+        "contentHash": "TDqkTKLfQuAaPcEb3pDDWnh7b3SyZF+/W9OZvWFp6eJCIiiYFdSB6taE2I6tWrFw5ywhzOb6sreoGJTI6m3rSQ==",
+        "dependencies": {
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.12.0",
+        "contentHash": "MiPEJQNyADfwZ4pJNpQex+t9/jOClBGMiCiVVFuELCMSX2nmNfvUor3uFVxNNCg30uxDP8JDYfPnMXQzsfzYyg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.12.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "System.IO.Packaging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "KYkIOAvPexQOLDxPO2g0BVoWInnQhPpkFzRqvNrNrMhVT6kqhVr0zEb6KCHlptLFukxnZrjuMVAnxK7pOGUYrw=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "simpleexcelexporter": {
+        "type": "Project",
+        "dependencies": {
+          "DocumentFormat.OpenXml": "[3.5.1, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Supersedes #8 (cross-repo fork PR hard to keep in sync). Same scope, plus post-review cleanup, release tooling, a shared-strings adoption, three file-size optimisations, and a behavior test suite.

## What this PR ships

### Apple Numbers / ECMA-376 strict compliance

XLSX files previously opened fine in Excel and LibreOffice but were rejected by Apple Numbers. This PR makes generated files compliant and validates on all three readers.

Concrete fixes (internal to `SpreadsheetWriter`, **public API unchanged**):

- Rows carry `r="N"`, cells carry `r="A1"` (via new `ColumnReferenceHelper.ToLetters`).
- `SheetDimension` computed from the actual used range.
- `[Content_Types].xml`: `Default Extension="xml"` set to `application/xml` + explicit `Override` for `core.xml`, with all `<Default>` entries before any `<Override>`.
- Text cells use the shared strings table (`t="s"` + index into `xl/sharedStrings.xml`); empty cells are omitted entirely so the reader infers the position from neighbouring `r` attributes (matches Excel's native behaviour).
- Default namespace (no `x:` prefix) on `<worksheet>`, `<workbook>`, `<styleSheet>`; `xmlns:r` on `<workbook>` root.
- `docProps/core.xml` populated with `dc:creator`, `dcterms:created`, `dcterms:modified`.
- `xl/styles.xml` complete with `numFmts`, `cellStyles`, `tableStyles`.
- Sequential `rIdN` (never GUIDs), all relationship targets relative.

### Streaming architecture

Writing targets the caller's stream directly — no intermediate `MemoryStream`, no ZIP reopening, no regex post-processing. Each ZIP entry is written exactly once with `XmlWriter` / `OpenXmlWriter`.

### Stylesheet simplification

Dropped the SDK `Stylesheet` object model entirely. All `CellFormat` instances produced by `CreateOrGetStylIndex` share the same shape except for `NumberFormatId`, so styles are tracked as a `List<uint>` and serialized inline in `WriteStyles` — cuts the old `BuildStylesheetSkeleton` dead state and removes any divergence risk between counter and emitted `<xf>` children.

### Shared strings table

Non-empty string cells route through `xl/sharedStrings.xml` with deduplication (dictionary-backed). Standard XLSX convention (Excel, openpyxl, EPPlus).

### Three size optimisations

Each is a single-line change, zero behaviour impact, accepted by every reader we tested:

- **A. Skip empty cells** — OOXML readers infer the empty position from surrounding `r` attributes.
- **B. Omit `s="0"`** — style index 0 is the OOXML default.
- **C. Omit `t="n"`** — numeric is the OOXML default cell type.

### Dependency bump

`DocumentFormat.OpenXml` `3.2.0` → `3.5.1`.

### CI / release tooling

- `dotnet.yml` (CI) runs on push/PR to master, **build + test only**, in `Release` configuration.
- `release.yml` triggers on tags `v*`: verifies the csproj has exactly one `<Version>` and that it matches the tag, then builds, tests, packs, publishes to NuGet (plus companion `.snupkg`), creates a GitHub Release.
- NuGet package cache on both workflows via `actions/setup-dotnet`, keyed by `**/packages.lock.json`.
- Lock files committed; CI uses `dotnet restore --locked-mode`.
- `ContinuousIntegrationBuild=true` on GitHub Actions + `Microsoft.SourceLink.GitHub 8.0.0` for deterministic, step-into-able packages.
- `.github/dependabot.yml` scans NuGet and GitHub Actions weekly with grouping.

### Docs

- `RELEASING.md` walks through bump → merge → tag → automated publish.
- `.github/pull_request_template.md` surfaces a checklist on every new PR.
- **`BENCHMARK_RESULTS.md`** + `scripts/benchmark.sh` (see below).

### Versioning

Bumped `<Version>` to `1.5.0-alpha.1`. Pre-release suffix is intentional — PCLOUD validates the new output format before the stable `1.5.0` tag is cut. MINOR rather than PATCH reflects Apple Numbers support being a new consumer capability.

## Performance & file-size impact (measured)

Controlled benchmark run (seeded `Random(42)`, 3 runs per version, medians reported). Full methodology and raw data in [`BENCHMARK_RESULTS.md`](BENCHMARK_RESULTS.md); harness is [`scripts/benchmark.sh`](scripts/benchmark.sh).

**1 M-row annotated fixture (`TestWithData3.xlsx`):**

| Version | Runtime | Δ vs master | File size | Δ vs master |
|---|---:|---:|---:|---:|
| master | **93.2 s** | — | **47.2 MB** | — |
| PR compliance baseline | 126.8 s | +36 % | 109.4 MB | +132 % |
| + shared strings | 125.6 s | +35 % | 109.2 MB | +132 % |
| + skip empty cells (A) | 128.7 s | +38 % | 97.7 MB | +107 % |
| + omit `s="0"` (B) | 128.4 s | +38 % | 96.7 MB | +105 % |
| + omit `t="n"` (C) — HEAD | 125.9 s | **+35 %** | **95.0 MB** | **+101 %** |

**Takeaways:**

1. **Compliance has a real cost.** Files are ~101 % larger and runtime is ~35 % slower than master. The dominant factor is `r="A1"` on every cell, required by Apple Numbers.
2. **Shared strings is perf-neutral on our data.** Kept because it's the standard XLSX convention; it would pay off on workloads with heavy string repetition.
3. **The three size optims (A + B + C) recover 14 MB** on the 1 M-row fixture (109 → 95 MB) — enough to drop under Google Sheets' 100 MB upload limit. They are **perf-neutral** (variations within ±3 s are noise).
4. On the `WorkbookDfn` fixture (`TestWithData4.xlsx`), which has no empty cells, optim A yields no gain; B and C each save ~0.4 MB.
5. On workloads with *all-unique* strings (`TestWithData5.xlsx`), shared strings slightly inflates the file (+46 KB) because there is nothing to deduplicate. Not a regression worth reverting — the convention benefit outweighs the edge case.

## Tests

48 total (up from 28 on master):

- `SpreadSheetWriterTest` — existing end-to-end paths; one expected cell count updated (4 → 3) because an empty header cell is no longer emitted.
- `SpreadSheetWriterOoxmlComplianceTest` — 7 structural invariants (row/cell `r`, dimension, content types Default-before-Override, shared-strings shape, default namespace, relationship targets relative, empty cells omitted).
- `SpreadSheetWriterBehaviorTest` — 16 semantic round-trip tests (value preservation per `CellDataType`, NumFmtId mapping, style dedup, `[IgnoreFromSpreadSheet]`, multi-worksheet, `[Index]` ordering). Designed to compile and pass on both master and this branch — drop the file onto master to certify non-regression.
- `ColumnReferenceHelperTest` — 11 column-letter conversion cases.

## Validated on

- Apple Numbers (macOS) — initial validation before the three size optims (A/B/C).
- Microsoft Excel (Windows + macOS).
- LibreOffice Calc.
- Google Sheets (upload size now under 100 MB on the 1 M-row fixture, but the 10 M-cell quota still blocks that specific workload).

**Open validation item**: the three size optims (commits `b57ebc5`, `7070d23`, `d298204`) were reasoned from the OOXML spec and checked against the SDK round-trip; they have not been re-validated on Apple Numbers directly. The generated `95 MB` file lives at `~/SimpleExcelExporter-bench-outputs/06-C-omit-tn/TestWithData3.xlsx` for a 30-second manual spot-check on a Mac.

## Follow-ups (tracked in `PERF_ANNOTATED_PATH.md`, out of scope here)

- After merge: tag `v1.5.0-alpha.1` → publishes the pre-release to NuGet → consuming project (PCLOUD) validates.
- Iterate with `-alpha.2`, `-alpha.3` if needed.
- Final `v1.5.0` tag for the stable release.
- Dedicated perf PR for the annotated-object path (cache `PropertyInfo[]` per type, replace string keys in attribute cache with tuples, precompute column-letter lookup). Perf claims on that PR will be backed by `scripts/benchmark.sh` runs, not single observations.
- Bump the `SimpleExcelExporter` dependency from `1.4.4` to `1.5.0` in consuming projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)