### PR TITLE
chore(release): bump version to 1.5.0-alpha.2

### DIFF
--- a/src/SimpleExcelExporter/SimpleExcelExporter.csproj
+++ b/src/SimpleExcelExporter/SimpleExcelExporter.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>1.5.0-alpha.1</Version>
+    <Version>1.5.0-alpha.2</Version>
     <WarningsAsErrors>CS8597;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8606;CS8607;CS8608;CS8609;CS8610;CS8611;CS8612;CS8613;CS8614;CS8615;CS8616;CS8617;CS8618;CS8619;CS8620;CS8621;CS8622;CS8624;CS8625;CS8626;CS8629;CS8631;CS8632;CS8633;CS8634;CS8638;CS8643;CS8644;CS8645;CS8653;CS8654;CS8655;CS8667;CS8714</WarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Helps exporting objects to an Excel file (.xlsx).</Description>


### PR DESCRIPTION
## Summary
- Bump `<Version>` from `1.5.0-alpha.1` to `1.5.0-alpha.2` in `src/SimpleExcelExporter/SimpleExcelExporter.csproj`.

## Context
`1.5.0-alpha.1` has become unusable in our Azure DevOps `PublicPackages` feed due to a tombstone that blocks both upstream re-fetch and manual republish. Publishing `1.5.0-alpha.2` (identical code) lets the downstream Prothesis2 project (branch `7864-fix-excel-mime-type-v2`) restore cleanly from the feed via the normal upstream mechanism.

## Test plan
- [ ] CI workflow `.NET` passes (build + test + pack + push to nuget.org)
- [ ] Package `1.5.0-alpha.2` appears on https://www.nuget.org/packages/SimpleExcelExporter