### PR TITLE
docs: note SimpleExcelExporterExample bump rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+## Companion repo: SimpleExcelExporterExample
+
+`../SimpleExcelExporterExample/` (https://github.com/Prothesis-Dental-Solutions/SimpleExcelExporterExample) is the public "getting started" sample, linked from this repo's `README.md`. It consumes `SimpleExcelExporter` via NuGet, not via `ProjectReference`, so it does **not** track `master` automatically.
+
+When bumping the library — `<Version>` or `<TargetFramework>` in `src/SimpleExcelExporter/SimpleExcelExporter.csproj` — update the example repo's `SimpleExcelExporterExample.csproj` in the same change set:
+
+- `<PackageReference Include="SimpleExcelExporter" Version="..." />` → new lib version
+- `<TargetFramework>` → match the lib
+
+If the public API changes, or the snippets in this repo's `README.md` change, also refresh `Program.cs` / `WorkbookDfnExample.cs` and the example README so the public-facing examples don't go stale.


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` documenting that the public-facing example repo (`SimpleExcelExporterExample`) consumes this lib via NuGet, not via `ProjectReference`, so it does not track `master` automatically.
- States that bumps to `<Version>` or `<TargetFramework>` in `src/SimpleExcelExporter/SimpleExcelExporter.csproj` must be mirrored in the example repo's csproj in the same change set, and that the example's snippets need a refresh when the API or this README's recommended usage changes.

## Context
The example repo had drifted to `1.1.0 / net6.0` while this repo was on `1.5.0 / net8.0` — and was missing the second usage pattern (`WorkbookDfn` — explicit, attribute-free) that this repo's `README.md` advertises. A companion PR brings the example back in sync; this PR documents the rule so it does not happen again.

## Test plan
- [x] Reviewer confirms wording matches our actual workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)